### PR TITLE
Remove redundant sidebar file list

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -15,3 +15,4 @@ pynvml==11.5.0
 psutil==6.1.1
 pytest==8.3.5
 pytest-asyncio==0.25.3
+pytest-cov==6.0.0

--- a/web/app.js
+++ b/web/app.js
@@ -10,8 +10,6 @@ const convList      = document.getElementById('conv-list');
 const newChatBtn    = document.getElementById('new-chat-btn');
 const sidebarToggle = document.getElementById('sidebar-toggle');
 const sidebar       = document.getElementById('sidebar');
-const docList           = document.getElementById('doc-list');
-const docUpload         = document.getElementById('doc-upload');
 const chatDocList       = document.getElementById('chat-doc-list');
 const chatDocUpload     = document.getElementById('chat-doc-upload');
 const chatDocsDivider   = document.getElementById('chat-docs-divider');
@@ -943,53 +941,9 @@ async function _uploadDoc(file, listEl, conversationId) {
     gpuFastInterval = null;
     placeholder.remove();
     if (conversationId) await fetchChatDocuments(conversationId);
-    else await fetchDocuments();
     await Promise.all([pollModelStatus(), pollAnalysisModelStatus()]);
   }
 }
-
-// ── Global documents ──────────────────────────────────────────
-
-/**
- * Fetches the list of globally-scoped documents from the API and renders them.
- *
- * @return {Promise<void>}
- */
-async function fetchDocuments() {
-  try {
-    const res = await fetch('/api/documents');
-    if (!res.ok) return;
-    renderDocList(await res.json());
-    updateScopeBadge();
-  } catch (_) {}
-}
-
-/**
- * Renders the global document list in the sidebar.
- *
- * Clears the existing list and rebuilds it.  Each item's delete button
- * calls the API and refreshes the list on success.
- *
- * @param {Array<{id: string, filename: string, chunk_count: number}>} docs - Documents
- *   returned by the API.
- * @return {void}
- */
-function renderDocList(docs) {
-  docList.innerHTML = '';
-  for (const doc of docs) {
-    docList.appendChild(_makeDocItem(doc, async () => {
-      await fetch(`/api/documents/${doc.id}`, { method: 'DELETE' });
-      await fetchDocuments();
-    }));
-  }
-}
-
-docUpload.addEventListener('change', async () => {
-  const file = docUpload.files[0];
-  if (!file) return;
-  docUpload.value = '';
-  await _uploadDoc(file, docList, null);
-});
 
 // ── Chat-scoped documents ─────────────────────────────────────
 
@@ -2486,7 +2440,6 @@ async function applySiteConfig() {
 applySiteConfig();
 fetchModels().then(() => Promise.all([pollModelStatus(), pollAnalysisModelStatus()]));
 fetchConversations();
-fetchDocuments();
 updateScopeBadge();
 
 // "Browse library" button in chat docs header → switch to workbench
@@ -2504,8 +2457,11 @@ if (browseLibraryBtn) {
 
 if (scopeBadge) {
   scopeBadge.addEventListener('click', () => {
-    sidebar.classList.remove('collapsed');
-    docList.closest('section,div')?.scrollIntoView?.({ behavior: 'smooth' });
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    document.querySelector('.tab-btn[data-tab="workbench"]').classList.add('active');
+    chatView.hidden      = true;
+    workbenchView.hidden = false;
+    loadWorkbench();
   });
 }
 fetchSystemPrompts();

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,7 @@
     #app (flex row)
     ├── <aside id="sidebar">     — collapsible left panel
     │     ├── conversation list  — populated by fetchConversations()
-    │     ├── global doc list    — populated by fetchDocuments()
+    │     ├── system prompt      — selector + inline editor
     │     └── chat doc list      — populated by fetchChatDocuments(); hidden until a conversation is active
     └── #main (flex column)
           ├── <header>           — branding, GPU meter, model selector
@@ -41,21 +41,6 @@
       <!-- Conversation history; items injected by renderConvList() -->
       <div id="conv-list" role="list"></div>
 
-      <div class="sidebar-divider"></div>
-
-      <!-- Global documents — persist across all conversations -->
-      <div class="sidebar-section-header">
-        <span>Global Documents</span>
-        <label id="upload-label" title="Upload document (.pdf, .docx, .txt, .md)">
-          +
-          <!-- Hidden file input; triggered by clicking the label -->
-          <input type="file" id="doc-upload" accept=".pdf,.docx,.xlsx,.txt,.md" hidden />
-        </label>
-      </div>
-      <div id="doc-list" role="list"></div>
-      <p class="copyright-notice">Documents may contain copyrighted material. You are responsible for ensuring your use complies with applicable licenses.</p>
-
-      <!-- System Prompts section -->
       <div class="sidebar-divider"></div>
       <div class="sidebar-section-header">
         <span>System Prompt</span>
@@ -316,8 +301,7 @@
               <tr><td>Escalate →</td><td>Appears below each assistant response. Sends the query to a cloud model (Anthropic/OpenAI) for a second opinion. Always requires manual approval if client documents were in context.</td></tr>
               <tr><td>Sources ▸</td><td>Collapsible section below each response showing which documents, chunk snippets, relevance scores, and graph nodes informed the answer. Shows "No documents matched" when RAG returned zero results.</td></tr>
               <tr><td>Scope badge</td><td>Persistent badge in the chat header showing the active scope (Global / Client:Name / Project:Name / Session), document count, and a ⚠ warning when the scope has zero documents.</td></tr>
-              <tr><td>Global Documents +</td><td>Upload a document visible across all conversations (global scope). Good for standards and reference material.</td></tr>
-              <tr><td>Chat Documents +</td><td>Upload a document scoped only to this conversation. Appears after the first conversation is started.</td></tr>
+              <tr><td>Chat Documents +</td><td>Upload a document scoped only to this conversation. Appears after the first conversation is started. For persistent documents, use the Workbench tab.</td></tr>
               <tr><td>System Prompt (sidebar)</td><td>Select a saved system prompt to assign it to the active conversation. Use + to create a new prompt, ✎ to edit the selected one. A "SP" badge appears on conversations that have a prompt assigned.</td></tr>
               <tr><td>⬇ Export (conv menu)</td><td>Export the active conversation as Markdown or JSON. Markdown includes the title, system prompt, model, and all messages. JSON includes the full conversation structure.</td></tr>
             </table>

--- a/web/styles.css
+++ b/web/styles.css
@@ -657,23 +657,6 @@ body { display: block; }
   color: var(--text-muted);
 }
 
-#upload-label {
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--text-muted);
-  padding: 0 4px;
-  border-radius: 4px;
-  transition: color 0.15s, background 0.15s;
-  line-height: 1;
-}
-
-#upload-label:hover { color: var(--gold); background: var(--surface-2); }
-
-#doc-list {
-  overflow-y: auto;
-  padding: 0 0 8px;
-}
 
 .doc-item {
   display: flex;
@@ -914,14 +897,6 @@ body { display: block; }
   opacity: 0.8;
 }
 
-/* ── Copyright notice ───────────────────────────────────────── */
-.copyright-notice {
-  font-size: 0.62rem;
-  color: #ffffff;
-  opacity: 0.6;
-  margin: 6px 8px 0;
-  line-height: 1.4;
-}
 
 /* ── Live search indicator ──────────────────────────────────── */
 .search-badge {


### PR DESCRIPTION
Closes #32

## Summary

The Global Documents section in the sidebar duplicated the Workbench document library with fewer capabilities (no sorting, filtering, type assignment, or multi-file upload). This PR removes it:

- Removed the Global Documents section header, upload input, doc list, and copyright notice from the sidebar HTML
- Removed `fetchDocuments()`, `renderDocList()`, and the sidebar upload change handler from `app.js`
- Removed `#upload-label`, `#doc-list`, and `.copyright-notice` CSS rules
- Updated the scope badge click handler to navigate to the Workbench tab instead of scrolling to the removed list
- Updated in-app help text to direct users to the Workbench for persistent documents

Chat-scoped documents, system prompts, and the conversation list remain in the sidebar unchanged.

## Test results

All 132 existing tests pass (`python3 -m pytest` — 132 passed, 2 warnings).

**Visual verification pending — automated agent. Manual browser check required before merge.**