### PR TITLE
Add classification selector to file upload

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1536,6 +1536,7 @@ const wbManageBtn    = document.getElementById('wb-manage-btn');
 const wbOpenChatBtn  = document.getElementById('wb-open-chat-btn');
 const wbTypeFilter   = document.getElementById('wb-type-filter');
 const wbUploadType   = document.getElementById('wb-upload-type');
+const wbUploadClass  = document.getElementById('wb-upload-classification');
 const wbDocUpload    = document.getElementById('wb-doc-upload');
 const wbUploadStatus = document.getElementById('wb-upload-status');
 const wbDocTbody     = document.getElementById('wb-doc-tbody');
@@ -1604,6 +1605,10 @@ async function setWbScope(scope) {
   wbScope = scope;
   wbOpenChatBtn.disabled = scope.type !== 'project';
   document.getElementById('wb-scope-label').textContent = scope.label;
+  const restricted = scope.type === 'client' || scope.type === 'project';
+  wbUploadClass.value = restricted ? 'client' : 'client';
+  wbUploadClass.disabled = restricted;
+  wbUploadClass.querySelector('option[value="public"]').disabled = restricted;
   renderWbScopeList();
   await loadWbDocs();
 }
@@ -1956,7 +1961,8 @@ wbDocUpload.addEventListener('change', async () => {
   if (!files.length) return;
   wbDocUpload.value = '';
 
-  const docType = wbUploadType.value;
+  const docType        = wbUploadType.value;
+  const classification = wbUploadClass.value;
   const total   = files.length;
   let   done    = 0;
   let   failed  = 0;
@@ -1971,6 +1977,7 @@ wbDocUpload.addEventListener('change', async () => {
     const fd = new FormData();
     fd.append('file', file);
     fd.append('doc_type', docType);
+    fd.append('classification', classification);
     fd.append('defer_index', 'true');
     if (wbScope.type === 'project' && wbScope.projectId) fd.append('project_id', wbScope.projectId);
     else if (wbScope.type === 'client' && wbScope.clientId) fd.append('client_id', wbScope.clientId);

--- a/web/index.html
+++ b/web/index.html
@@ -223,6 +223,10 @@
                 <option value="plc_code">PLC Code</option>
                 <option value="misc" selected>Misc</option>
               </select>
+              <select id="wb-upload-classification" title="Classification to assign on upload">
+                <option value="client" selected>Client</option>
+                <option value="public">Public</option>
+              </select>
               <label id="wb-upload-label" class="wb-upload-btn" title="Upload documents to selected scope (select multiple)">
                 + Upload
                 <input type="file" id="wb-doc-upload" accept=".pdf,.docx,.xlsx,.txt,.md,.st,.scl" multiple hidden />
@@ -320,14 +324,14 @@
               <tr><td>Completeness grid</td><td>Shown only when a project is selected. Green = present; red = safety-critical doc missing (THEOP, FMEA, HA, FAT, SAT); grey = non-critical absent.</td></tr>
               <tr><td>Type filter</td><td>Filter the document list by document type.</td></tr>
               <tr><td>Column header (click)</td><td>Sort the document table by that column. Click again to reverse direction.</td></tr>
-              <tr><td>Upload as / + Upload</td><td>Select one or many files to upload to the selected scope. Files are stored and embedded immediately but concept extraction is deferred — categorise them first, then click Index Documents.</td></tr>
+              <tr><td>Upload as / + Upload</td><td>Select document type and classification before uploading. Files are stored and embedded immediately but concept extraction is deferred — categorise them first, then click Index Documents. Classification is locked to Client (confidential) for client- and project-scoped uploads.</td></tr>
               <tr><td>Index Documents</td><td>Run concept extraction and summarisation on all documents in the current scope. Use this after uploading and categorising a batch of files.</td></tr>
               <tr><td>Open in Chat</td><td>Switch to Chat tab with this project's full document scope loaded as context.</td></tr>
               <tr><td>⬇ (row)</td><td>Download the original source document.</td></tr>
               <tr><td>✎ (row)</td><td>Edit the document's filename, type, and classification inline without re-uploading.</td></tr>
               <tr><td>✕ (row)</td><td>Delete a document. Removes it from storage and the knowledge graph. Requires confirmation.</td></tr>
             </table>
-            <div class="help-tip">Recommended workflow for a batch of new documents: Upload all files → use ✎ to set the correct type on each → click Index Documents to build the knowledge graph.</div>
+            <div class="help-tip">Recommended workflow for a batch of new documents: Set the document type and classification → upload all files → use ✎ to adjust individual attributes if needed → click Index Documents to build the knowledge graph.</div>
           </div>
 
           <div class="help-section">
@@ -370,7 +374,7 @@
               <dt>Public</dt><dd>Technical library documents (manufacturer manuals, standards). Eligible for auto-escalation when <code>AUTO_ESCALATE=true</code>.</dd>
               <dt>Client</dt><dd>Any client or project file, or anything sourced from M-Files. Cloud escalation always requires explicit manual approval. Never exposed in the public library view.</dd>
             </dl>
-            <p>Classification is set automatically at upload based on scope and source, and can be changed afterwards using the ✎ edit button (except for client- and project-scoped documents, which are always client-confidential).</p>
+            <p>Classification can be set at upload time using the classification selector next to the type dropdown. For client- and project-scoped uploads, classification is locked to Client (confidential). It can also be changed afterwards using the ✎ edit button.</p>
           </div>
 
           <div class="help-section">


### PR DESCRIPTION
Closes #33

Adds a classification dropdown (Client / Public) to the workbench upload controls, so users can set classification at upload time instead of editing it afterwards. The selector sits between the document-type dropdown and the + Upload button.

- For client- and project-scoped uploads, the selector is locked to Client (confidential), matching the backend's existing enforcement in `routers/documents.py:220-223`.
- For global uploads, defaults to Client but allows switching to Public.
- The `classification` value is sent as a FormData field on every upload — the API already accepts this parameter.

Updated embedded help text (upload controls row, recommended workflow tip, classification section) to reflect the new upload-time attribute.

**Tests:** 132 passed, 0 failed (no backend changes — frontend-only).

**Visual verification pending — automated agent. Manual browser check required before merge.**