### PR TITLE
Sync upload doc-type selector with full type list

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1635,6 +1635,14 @@ const _WB_DOC_TYPE_OPTIONS = [
   ['app_note','App Note'], ['misc','Misc'],
 ];
 
+_WB_DOC_TYPE_OPTIONS.forEach(([v, l]) => {
+  const opt = document.createElement('option');
+  opt.value = v;
+  opt.textContent = l;
+  if (v === 'misc') opt.selected = true;
+  wbUploadType.appendChild(opt);
+});
+
 const _WB_SAFETY_CRITICAL_TYPES = ['theop', 'fmea', 'hazard_analysis', 'fat', 'sat'];
 const _WB_ALL_COMPLETENESS_TYPES = [
   'theop', 'fmea', 'hazard_analysis', 'fat', 'sat',

--- a/web/index.html
+++ b/web/index.html
@@ -211,17 +211,6 @@
             </span>
             <div class="wb-upload-group">
               <select id="wb-upload-type" title="Document type to assign on upload">
-                <option value="standard">Standard</option>
-                <option value="requirement">Requirement</option>
-                <option value="theop">THEOP</option>
-                <option value="fmea">FMEA</option>
-                <option value="hazard_analysis">Hazard Analysis</option>
-                <option value="fat">FAT</option>
-                <option value="sat">SAT</option>
-                <option value="contract">Contract</option>
-                <option value="correspondence">Correspondence</option>
-                <option value="plc_code">PLC Code</option>
-                <option value="misc" selected>Misc</option>
               </select>
               <select id="wb-upload-classification" title="Classification to assign on upload">
                 <option value="client" selected>Client</option>


### PR DESCRIPTION
## Summary

Closes #33

The Workbench upload `<select>` was hardcoded with 11 document types, but the API (`models.DOC_TYPES`) and the inline edit form (`_WB_DOC_TYPE_OPTIONS`) both support 15. Four types — Technical Manual, Datasheet, Firmware Notes, and App Note — could only be assigned after upload via the edit row, not at upload time.

This replaces the static HTML `<option>` list with a JS loop that populates the selector from `_WB_DOC_TYPE_OPTIONS`, the same array the inline edit form already uses. Both selectors now stay in sync automatically.

## Test results

All 132 existing tests pass (no backend changes — this is a frontend-only fix).

**Visual verification pending — automated agent. Manual browser check required before merge.**