### PR TITLE
Copyright acknowledgement popup on new chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No data leaves your machine unless you explicitly approve it.
 - **Autonomous web search** — tool-capable models (Qwen3, Qwen2.5, Mistral) search DuckDuckGo automatically when current information is needed
 - **URL fetching** — paste a URL into your message and the page content is fetched and included as context
 - **Escalate to Cloud** — each assistant response has an "Escalate →" button to send the query to a cloud model (Anthropic/OpenAI) for a second opinion; held for manual approval if client documents are in context
+- **Copyright acknowledgement** — a compliance notice is shown once per browser session before the chat input is enabled, reminding users that uploaded and discussed material may be copyrighted
 
 ### Technical Library
 - **Category browser** — documents grouped by type (Standards, Manuals, Datasheets, etc.) with a per-source filter; not all library documents are manufacturer docs

--- a/web/app.js
+++ b/web/app.js
@@ -798,11 +798,46 @@ async function deleteConversation(id) {
   } catch (_) {}
 }
 
+// ── Copyright acknowledgement ─────────────────────────────────
+// Must be acknowledged once per browser session before a chat can be used.
+const COPYRIGHT_ACK_KEY = 'lancellmot_copyright_ack';
+const copyrightBackdrop = document.getElementById('copyright-backdrop');
+const copyrightModal    = document.getElementById('copyright-modal');
+const copyrightAckBtn   = document.getElementById('copyright-ack-btn');
+
+function copyrightAcknowledged() {
+  try { return sessionStorage.getItem(COPYRIGHT_ACK_KEY) === '1'; }
+  catch (_) { return false; }
+}
+
+function showCopyrightNotice() {
+  copyrightBackdrop.hidden = false;
+  copyrightModal.hidden    = false;
+  input.disabled           = true;
+  sendBtn.disabled         = true;
+  copyrightAckBtn.focus();
+}
+
+function acknowledgeCopyright() {
+  try { sessionStorage.setItem(COPYRIGHT_ACK_KEY, '1'); } catch (_) {}
+  copyrightBackdrop.hidden = true;
+  copyrightModal.hidden    = true;
+  input.disabled           = false;
+  sendBtn.disabled         = false;
+  input.focus();
+}
+
+copyrightAckBtn.addEventListener('click', acknowledgeCopyright);
+
+if (!copyrightAcknowledged()) showCopyrightNotice();
+
 /**
  * Resets the UI to a blank new-chat state.
  *
  * Clears the chat window, empties the chat-document list, deselects any
  * active sidebar item, hides the chat-docs section, and focuses the input.
+ * Requires the copyright notice to be acknowledged before the input is
+ * usable (per issue #36).
  *
  * @return {void}
  */
@@ -813,6 +848,10 @@ function newChat() {
   setActiveConvItem(null);
   setChatDocsVisible(false);
   syncSpForConversation(null);
+  if (!copyrightAcknowledged()) {
+    showCopyrightNotice();
+    return;
+  }
   input.focus();
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -295,6 +295,11 @@
           </div>
 
           <div class="help-section">
+            <h3>Copyright notice</h3>
+            <p>A copyright acknowledgement dialog is shown once per browser session before the chat input is enabled. Documents and prompts may contain copyrighted material, and you remain responsible for ensuring that your use complies with applicable licenses. Prefer summaries, citations, and analysis over verbatim reproduction.</p>
+          </div>
+
+          <div class="help-section">
             <h3>Chat tab</h3>
             <p>The main chat interface. Send messages to the AI and it will draw on your uploaded documents as context (RAG — retrieval-augmented generation).</p>
             <table class="help-table">
@@ -424,6 +429,23 @@
       <div id="export-menu" class="export-menu" hidden>
         <button id="export-md-btn">Markdown (.md)</button>
         <button id="export-json-btn">JSON (.json)</button>
+      </div>
+
+      <!-- ── Copyright acknowledgement modal ── -->
+      <!-- Must be explicitly dismissed; backdrop click and ESC do not close it. -->
+      <div id="copyright-backdrop" class="modal-backdrop" hidden></div>
+      <div id="copyright-modal" class="modal copyright-modal" role="alertdialog"
+           aria-labelledby="copyright-title" aria-describedby="copyright-body" hidden>
+        <div class="modal-head">
+          <span class="modal-head-title" id="copyright-title">COPYRIGHT NOTICE</span>
+        </div>
+        <div class="modal-body" id="copyright-body">
+          <p>Documents and materials uploaded to or discussed within LanceLLMot may contain copyrighted content. You are responsible for ensuring that your use — including the queries you send and any output you rely on — complies with applicable copyright, licensing, and confidentiality obligations.</p>
+          <p>Prefer summaries, citations, and analysis over verbatim reproduction of third-party material.</p>
+        </div>
+        <div class="modal-foot" style="justify-content:flex-end">
+          <button class="wb-chat-btn" id="copyright-ack-btn">I Understand</button>
+        </div>
       </div>
 
       <!-- ── Status bar ── -->

--- a/web/styles.css
+++ b/web/styles.css
@@ -1338,6 +1338,9 @@ body { display: block; }
 }
 
 .help-modal { width: 620px; }
+.copyright-modal { width: 480px; }
+.copyright-modal .modal-body p { margin: 0 0 10px; line-height: 1.5; }
+.copyright-modal .modal-body p:last-child { margin-bottom: 0; }
 
 .modal-head {
   display: flex;


### PR DESCRIPTION
Closes #36

## Summary

Issue #35 removed the inline copyright notice from the sidebar when the Global Documents list was deleted. This PR restores the notice as an explicit acknowledgement modal that must be clicked before the chat input becomes usable — so users are reminded of their copyright obligations before sending anything into the model.

**Behaviour**

- Modal shown on initial page load and whenever `newChat()` is invoked, if the user has not yet acknowledged in the current browser session.
- Acknowledgement is stored in `sessionStorage` (`lancellmot_copyright_ack=1`) so the user is prompted once per browser session rather than once per click of "+ New Chat".
- While the modal is open, the composer `<textarea>` and Send button are disabled.
- The modal is **not** dismissible via the backdrop or the ESC key — the user must click the "I Understand" button. This is deliberate for a compliance-style acknowledgement.
- The copyright text is the same wording the sidebar notice used (see commit a01e368).
- `role="alertdialog"` with `aria-labelledby` / `aria-describedby` for screen-reader compatibility.

**Docs**

- Help modal: new "Copyright notice" section explains when the dialog appears and why.
- README: a bullet in the Chat & RAG features list mentions the acknowledgement.

## Test results

`cd api && python3 -m pytest` — 132 passed (unchanged; this PR is frontend-only). 2 pre-existing deprecation warnings about FastAPI `on_event` startup hooks are not related to this change.

**Visual verification pending — automated agent. Manual browser check required before merge.**