### PR TITLE
Re-trigger copyright modal on every new chat + on chats with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ No data leaves your machine unless you explicitly approve it.
 - **Autonomous web search** — tool-capable models (Qwen3, Qwen2.5, Mistral) search DuckDuckGo automatically when current information is needed
 - **URL fetching** — paste a URL into your message and the page content is fetched and included as context
 - **Escalate to Cloud** — each assistant response has an "Escalate →" button to send the query to a cloud model (Anthropic/OpenAI) for a second opinion; held for manual approval if client documents are in context
-- **Copyright acknowledgement** — a compliance notice is shown once per browser session before the chat input is enabled, reminding users that uploaded and discussed material may be copyrighted
+- **Copyright acknowledgement** — a compliance notice is shown on page load, on every new chat (including those started from the Workbench), and whenever a conversation with attached documents is opened, reminding users that uploaded and discussed material may be copyrighted
 
 ### Technical Library
 - **Category browser** — documents grouped by type (Standards, Manuals, Datasheets, etc.) with a per-source filter; not all library documents are manufacturer docs

--- a/web/app.js
+++ b/web/app.js
@@ -775,7 +775,11 @@ async function loadConversation(id) {
     setChatDocsVisible(true);
     await fetchChatDocuments();
     syncSpForConversation(conv);
-    input.focus();
+    if (chatDocList.children.length > 0) {
+      showCopyrightNotice();
+    } else {
+      input.focus();
+    }
   } catch (_) {}
 }
 
@@ -799,16 +803,12 @@ async function deleteConversation(id) {
 }
 
 // ── Copyright acknowledgement ─────────────────────────────────
-// Must be acknowledged once per browser session before a chat can be used.
-const COPYRIGHT_ACK_KEY = 'lancellmot_copyright_ack';
+// Shown on page load, on every newChat(), and whenever a conversation with
+// attached documents is opened — reminding the user of their obligations
+// before they act on potentially copyrighted material.
 const copyrightBackdrop = document.getElementById('copyright-backdrop');
 const copyrightModal    = document.getElementById('copyright-modal');
 const copyrightAckBtn   = document.getElementById('copyright-ack-btn');
-
-function copyrightAcknowledged() {
-  try { return sessionStorage.getItem(COPYRIGHT_ACK_KEY) === '1'; }
-  catch (_) { return false; }
-}
 
 function showCopyrightNotice() {
   copyrightBackdrop.hidden = false;
@@ -819,7 +819,6 @@ function showCopyrightNotice() {
 }
 
 function acknowledgeCopyright() {
-  try { sessionStorage.setItem(COPYRIGHT_ACK_KEY, '1'); } catch (_) {}
   copyrightBackdrop.hidden = true;
   copyrightModal.hidden    = true;
   input.disabled           = false;
@@ -829,7 +828,7 @@ function acknowledgeCopyright() {
 
 copyrightAckBtn.addEventListener('click', acknowledgeCopyright);
 
-if (!copyrightAcknowledged()) showCopyrightNotice();
+showCopyrightNotice();
 
 /**
  * Resets the UI to a blank new-chat state.
@@ -848,11 +847,7 @@ function newChat() {
   setActiveConvItem(null);
   setChatDocsVisible(false);
   syncSpForConversation(null);
-  if (!copyrightAcknowledged()) {
-    showCopyrightNotice();
-    return;
-  }
-  input.focus();
+  showCopyrightNotice();
 }
 
 newChatBtn.addEventListener('click', () => {

--- a/web/index.html
+++ b/web/index.html
@@ -285,7 +285,7 @@
 
           <div class="help-section">
             <h3>Copyright notice</h3>
-            <p>A copyright acknowledgement dialog is shown once per browser session before the chat input is enabled. Documents and prompts may contain copyrighted material, and you remain responsible for ensuring that your use complies with applicable licenses. Prefer summaries, citations, and analysis over verbatim reproduction.</p>
+            <p>A copyright acknowledgement dialog is shown on page load, every time a new chat is started (including from the Workbench), and whenever you open an existing conversation that has documents attached. Documents and prompts may contain copyrighted material, and you remain responsible for ensuring that your use complies with applicable licenses.</p>
           </div>
 
           <div class="help-section">
@@ -430,7 +430,6 @@
         </div>
         <div class="modal-body" id="copyright-body">
           <p>Documents and materials uploaded to or discussed within LanceLLMot may contain copyrighted content. You are responsible for ensuring that your use — including the queries you send and any output you rely on — complies with applicable copyright, licensing, and confidentiality obligations.</p>
-          <p>Prefer summaries, citations, and analysis over verbatim reproduction of third-party material.</p>
         </div>
         <div class="modal-foot" style="justify-content:flex-end">
           <button class="wb-chat-btn" id="copyright-ack-btn">I Understand</button>


### PR DESCRIPTION
Closes #43 — follow-up to #36 / PR #42.

## Summary

The modal previously only fired once per browser session (sessionStorage gate). The intended compliance behavior is to re-prompt **every** time a chat is started and whenever a conversation with attached documents is opened.

- Drop \`COPYRIGHT_ACK_KEY\` / \`copyrightAcknowledged()\` / \`sessionStorage.setItem\` — acknowledgement is now a one-shot dismiss of the current modal instance.
- \`newChat()\` unconditionally calls \`showCopyrightNotice()\` — covers the top-level "+ New Chat" button, the workbench "Open Chat" action, and the workbench attach-doc flow that creates a conversation.
- \`loadConversation()\` calls \`showCopyrightNotice()\` after \`fetchChatDocuments()\` when the rendered doc list is non-empty.
- Drop the filler "prefer summaries..." line from the modal body and help section.
- Update the help modal copy and the README feature bullet to describe the new triggers.

## Test results

\`cd api && python3 -m pytest -q\` — 132 passed. Frontend-only change; no backend logic touched.

**Visual verification pending — manual browser check required before merge.**