### PR TITLE
web: bulk edit document attributes (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ No data leaves your machine unless you explicitly approve it.
 
 ### Workbench
 - **Document attribute editing** — after upload, click the ✎ button on any document to edit its filename, doc type, and classification inline
+- **Bulk attribute editing** — select multiple documents with the row checkboxes (or the header checkbox to toggle everything currently shown) and apply doc type, scope, and classification to all of them in one step; any field left at "Keep current" is unchanged per-document
 - **Scope hierarchy** — global, client, project, and session scopes; project view inherits all parent-scope documents
 
 ### System

--- a/web/app.js
+++ b/web/app.js
@@ -1590,6 +1590,9 @@ let wbDocs        = [];
 let wbScope = { type: 'global', clientId: null, projectId: null, label: 'Global' };
 let wbSortKey = null;
 let wbSortAsc = true;
+// Doc IDs currently checked in the table. Cleared whenever the underlying
+// doc list reloads — the render pass drops any IDs no longer present.
+const wbSelectedIds = new Set();
 
 function _esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 
@@ -1742,18 +1745,28 @@ function renderWbDocs() {
   const filter = wbTypeFilter.value;
   const filtered = wbDocs.filter(d => !filter || d.doc_type === filter);
   const rows = sortWbRows(filtered);
+
+  // Drop any selections that are no longer visible (scope change, filter change,
+  // or deletion) so the bulk bar count always reflects reality.
+  const visibleIds = new Set(rows.map(d => d.id));
+  for (const id of wbSelectedIds) if (!visibleIds.has(id)) wbSelectedIds.delete(id);
+
   if (!rows.length) {
     const msg = wbScope.type === 'global' && !wbClients.length
       ? 'No global documents yet. Upload a standard or reference document using the + Upload button.'
       : 'No documents found for this scope.';
-    wbDocTbody.innerHTML = `<tr class="wb-empty-row"><td colspan="6">${msg}</td></tr>`;
+    wbDocTbody.innerHTML = `<tr class="wb-empty-row"><td colspan="7">${msg}</td></tr>`;
+    updateWbBulkBar();
     return;
   }
   wbDocTbody.innerHTML = '';
   rows.forEach(d => {
     const tr = document.createElement('tr');
     const date = (d.created_at || '').slice(0, 10);
+    const checked = wbSelectedIds.has(d.id) ? ' checked' : '';
+    if (checked) tr.classList.add('wb-row-selected');
     tr.innerHTML = `
+      <td class="wb-check-col"><input type="checkbox" class="wb-row-check" data-id="${d.id}"${checked} /></td>
       <td title="${_esc(d.filename)}">${_esc(d.filename)}</td>
       <td><span class="doc-type-badge">${_esc(d.doc_type)}</span></td>
       <td><span class="scope-badge ${d.scope_type}">${d.scope_type}</span></td>
@@ -1767,6 +1780,7 @@ function renderWbDocs() {
       </td>`;
     wbDocTbody.appendChild(tr);
   });
+  updateWbBulkBar();
 }
 
 function _openWbEdit(tr, doc) {
@@ -1982,6 +1996,201 @@ document.querySelector('.wb-table thead').addEventListener('click', e => {
   if (wbSortKey === key) wbSortAsc = !wbSortAsc;
   else { wbSortKey = key; wbSortAsc = true; }
   renderWbDocs();
+});
+
+// ── Bulk selection + edit ─────────────────────────────────────
+const wbCheckAll        = document.getElementById('wb-check-all');
+const wbBulkBar         = document.getElementById('wb-bulk-bar');
+const wbBulkCountN      = document.getElementById('wb-bulk-count-n');
+const wbBulkEditBtn     = document.getElementById('wb-bulk-edit-btn');
+const wbBulkClearBtn    = document.getElementById('wb-bulk-clear-btn');
+const wbBulkBackdrop    = document.getElementById('wb-bulk-backdrop');
+const wbBulkModal       = document.getElementById('wb-bulk-modal');
+const wbBulkClose       = document.getElementById('wb-bulk-close');
+const wbBulkCancel      = document.getElementById('wb-bulk-cancel');
+const wbBulkSave        = document.getElementById('wb-bulk-save');
+const wbBulkTargetN     = document.getElementById('wb-bulk-target-n');
+const wbBulkDocType     = document.getElementById('wb-bulk-doc-type');
+const wbBulkScope       = document.getElementById('wb-bulk-scope');
+const wbBulkClass       = document.getElementById('wb-bulk-classification');
+const wbBulkWarning     = document.getElementById('wb-bulk-warning');
+const wbBulkStatus      = document.getElementById('wb-bulk-status');
+
+function updateWbBulkBar() {
+  const n = wbSelectedIds.size;
+  wbBulkBar.hidden = n === 0;
+  wbBulkCountN.textContent = String(n);
+  // Keep the "select all" checkbox state aligned with the rendered rows.
+  const rowChecks = wbDocTbody.querySelectorAll('.wb-row-check');
+  const total = rowChecks.length;
+  const checked = Array.from(rowChecks).filter(c => c.checked).length;
+  wbCheckAll.checked       = total > 0 && checked === total;
+  wbCheckAll.indeterminate = checked > 0 && checked < total;
+}
+
+wbDocTbody.addEventListener('change', e => {
+  const cb = e.target.closest('.wb-row-check');
+  if (!cb) return;
+  const id = cb.dataset.id;
+  if (cb.checked) wbSelectedIds.add(id);
+  else wbSelectedIds.delete(id);
+  cb.closest('tr').classList.toggle('wb-row-selected', cb.checked);
+  updateWbBulkBar();
+});
+
+wbCheckAll.addEventListener('change', () => {
+  const want = wbCheckAll.checked;
+  wbDocTbody.querySelectorAll('.wb-row-check').forEach(cb => {
+    cb.checked = want;
+    const id = cb.dataset.id;
+    if (want) wbSelectedIds.add(id);
+    else wbSelectedIds.delete(id);
+    cb.closest('tr').classList.toggle('wb-row-selected', want);
+  });
+  updateWbBulkBar();
+});
+
+wbBulkClearBtn.addEventListener('click', () => {
+  wbSelectedIds.clear();
+  wbDocTbody.querySelectorAll('.wb-row-check').forEach(cb => {
+    cb.checked = false;
+    cb.closest('tr').classList.remove('wb-row-selected');
+  });
+  updateWbBulkBar();
+});
+
+function _buildBulkScopeOptions() {
+  const opts = ['<option value="">Keep current</option>',
+                '<option value="global:">Global</option>'];
+  wbClients.forEach(c => {
+    opts.push(`<option value="client:${_esc(c.id)}">Client: ${_esc(c.name)}</option>`);
+  });
+  wbAllProjects.forEach(p => {
+    const cl = wbClients.find(c => c.id === p.client_id);
+    const lbl = cl ? `${_esc(p.name)} (${_esc(cl.name)})` : _esc(p.name);
+    opts.push(`<option value="project:${_esc(p.id)}">Project: ${lbl}</option>`);
+  });
+  return opts.join('');
+}
+
+function _buildBulkDocTypeOptions() {
+  const opts = ['<option value="">Keep current</option>'];
+  _WB_DOC_TYPE_OPTIONS.forEach(([v, l]) => {
+    opts.push(`<option value="${v}">${l}</option>`);
+  });
+  return opts.join('');
+}
+
+function _refreshBulkWarning() {
+  // Warn if the user picked classification=public while also moving scope to
+  // client/project — the backend will reject it, so catch it client-side.
+  const scopeVal = wbBulkScope.value;
+  const cls = wbBulkClass.value;
+  const restricted = scopeVal.startsWith('client:') || scopeVal.startsWith('project:');
+  if (restricted && cls === 'public') {
+    wbBulkWarning.textContent = 'Client and project scopes cannot be classified as public. Pick a different classification or leave it at Keep current.';
+    wbBulkWarning.hidden = false;
+  } else {
+    wbBulkWarning.hidden = true;
+  }
+}
+
+function openBulkModal() {
+  if (wbSelectedIds.size === 0) return;
+  wbBulkDocType.innerHTML = _buildBulkDocTypeOptions();
+  wbBulkScope.innerHTML   = _buildBulkScopeOptions();
+  wbBulkDocType.value = '';
+  wbBulkScope.value   = '';
+  wbBulkClass.value   = '';
+  wbBulkTargetN.textContent = String(wbSelectedIds.size);
+  wbBulkWarning.hidden = true;
+  wbBulkStatus.textContent = '';
+  wbBulkSave.disabled = false;
+  wbBulkSave.textContent = 'Apply';
+  wbBulkBackdrop.hidden = false;
+  wbBulkModal.hidden    = false;
+}
+
+function closeBulkModal() {
+  wbBulkBackdrop.hidden = true;
+  wbBulkModal.hidden    = true;
+}
+
+wbBulkEditBtn.addEventListener('click', openBulkModal);
+wbBulkClose .addEventListener('click', closeBulkModal);
+wbBulkCancel.addEventListener('click', closeBulkModal);
+wbBulkBackdrop.addEventListener('click', closeBulkModal);
+wbBulkScope .addEventListener('change', _refreshBulkWarning);
+wbBulkClass .addEventListener('change', _refreshBulkWarning);
+
+wbBulkSave.addEventListener('click', async () => {
+  const ids = Array.from(wbSelectedIds);
+  if (!ids.length) { closeBulkModal(); return; }
+
+  const body = {};
+  if (wbBulkDocType.value) body.doc_type = wbBulkDocType.value;
+  if (wbBulkScope.value) {
+    const [scope_type, scope_id] = wbBulkScope.value.split(':');
+    body.scope_type = scope_type;
+    body.scope_id   = scope_id || null;
+  }
+  if (wbBulkClass.value) body.classification = wbBulkClass.value;
+
+  if (!Object.keys(body).length) {
+    wbBulkStatus.textContent = 'Nothing to change — pick at least one field.';
+    return;
+  }
+
+  const restricted = body.scope_type === 'client' || body.scope_type === 'project';
+  if (restricted && body.classification === 'public') {
+    _refreshBulkWarning();
+    return;
+  }
+
+  wbBulkSave.disabled = true;
+  wbBulkSave.textContent = 'Applying…';
+  wbBulkStatus.textContent = `0 / ${ids.length} done`;
+
+  let done = 0;
+  let failed = 0;
+  const firstErrors = [];
+  await Promise.all(ids.map(async id => {
+    try {
+      const res = await fetch(`/api/documents/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        done++;
+      } else {
+        failed++;
+        if (firstErrors.length < 3) {
+          const err = await res.json().catch(() => ({}));
+          firstErrors.push(err.detail || `HTTP ${res.status}`);
+        }
+      }
+    } catch {
+      failed++;
+      if (firstErrors.length < 3) firstErrors.push('Network error');
+    } finally {
+      wbBulkStatus.textContent = `${done + failed} / ${ids.length} done`;
+    }
+  }));
+
+  if (failed === 0) {
+    closeBulkModal();
+    wbSelectedIds.clear();
+    await loadWbDocs();
+    setStatus(`Updated ${done} document${done === 1 ? '' : 's'}.`, 'info');
+  } else {
+    wbBulkSave.disabled = false;
+    wbBulkSave.textContent = 'Apply';
+    wbBulkStatus.textContent = `${done} updated, ${failed} failed — ${firstErrors.join('; ')}`;
+    // Reload the table so successful updates are reflected; selections that
+    // actually succeeded are no longer on those rows' old state.
+    await loadWbDocs();
+  }
 });
 
 wbOpenChatBtn.addEventListener('click', () => {

--- a/web/index.html
+++ b/web/index.html
@@ -227,20 +227,59 @@
             <button id="wb-open-chat-btn" class="wb-chat-btn" disabled title="Open a new chat with this project's documents in context">Open in Chat</button>
           </div>
 
+          <div id="wb-bulk-bar" class="wb-bulk-bar" hidden>
+            <span class="wb-bulk-count"><strong id="wb-bulk-count-n">0</strong> selected</span>
+            <button id="wb-bulk-edit-btn" class="wb-chat-btn" title="Edit type, scope, or classification for the selected documents">Edit attributes</button>
+            <button id="wb-bulk-clear-btn" class="icon-btn" title="Clear selection">Clear</button>
+          </div>
+
           <div class="wb-table-wrap">
             <table class="wb-table">
               <thead>
                 <tr>
-                  <th class="sortable" data-sort-key="filename">Filename</th><th class="sortable" data-sort-key="doc_type">Type</th><th class="sortable" data-sort-key="scope_type">Scope</th><th class="sortable" data-sort-key="created_at">Uploaded</th><th class="sortable" data-sort-key="chunk_count">Chunks</th><th></th>
+                  <th class="wb-check-col"><input type="checkbox" id="wb-check-all" title="Select all visible documents" /></th><th class="sortable" data-sort-key="filename">Filename</th><th class="sortable" data-sort-key="doc_type">Type</th><th class="sortable" data-sort-key="scope_type">Scope</th><th class="sortable" data-sort-key="created_at">Uploaded</th><th class="sortable" data-sort-key="chunk_count">Chunks</th><th></th>
                 </tr>
               </thead>
               <tbody id="wb-doc-tbody">
-                <tr class="wb-empty-row"><td colspan="6">Select a scope from the panel to view documents.</td></tr>
+                <tr class="wb-empty-row"><td colspan="7">Select a scope from the panel to view documents.</td></tr>
               </tbody>
             </table>
           </div>
         </div>
 
+      </div>
+
+
+      <!-- ── Bulk edit modal ── -->
+      <div id="wb-bulk-backdrop" class="modal-backdrop" hidden></div>
+      <div id="wb-bulk-modal" class="modal" hidden>
+        <div class="modal-head">
+          <span class="modal-head-title">EDIT ATTRIBUTES</span>
+          <button class="modal-close" id="wb-bulk-close">✕</button>
+        </div>
+        <div class="modal-body">
+          <p class="wb-bulk-target">Applying to <strong id="wb-bulk-target-n">0</strong> selected document(s). Fields left at <em>Keep current</em> are unchanged per document.</p>
+          <div class="wb-bulk-form">
+            <label class="wb-edit-label" for="wb-bulk-doc-type">Type</label>
+            <select id="wb-bulk-doc-type" class="wb-edit-select"></select>
+            <label class="wb-edit-label" for="wb-bulk-scope">Scope</label>
+            <select id="wb-bulk-scope" class="wb-edit-select"></select>
+            <label class="wb-edit-label" for="wb-bulk-classification">Classification</label>
+            <select id="wb-bulk-classification" class="wb-edit-select">
+              <option value="">Keep current</option>
+              <option value="client">Client (confidential)</option>
+              <option value="public">Public</option>
+            </select>
+          </div>
+          <p id="wb-bulk-warning" class="wb-bulk-warning" hidden></p>
+        </div>
+        <div class="modal-foot">
+          <span id="wb-bulk-status" class="wb-upload-status"></span>
+          <div style="display:flex; gap:8px;">
+            <button id="wb-bulk-cancel" class="wb-edit-cancel">Cancel</button>
+            <button id="wb-bulk-save" class="wb-edit-save">Apply</button>
+          </div>
+        </div>
       </div>
 
 
@@ -323,6 +362,8 @@
               <tr><td>Open in Chat</td><td>Switch to Chat tab with this project's full document scope loaded as context.</td></tr>
               <tr><td>⬇ (row)</td><td>Download the original source document.</td></tr>
               <tr><td>✎ (row)</td><td>Edit the document's filename, type, and classification inline without re-uploading.</td></tr>
+              <tr><td>☐ (row / header)</td><td>Select documents. The header checkbox toggles every row currently shown. A bulk-edit bar appears above the table with an Edit attributes button when at least one row is selected.</td></tr>
+              <tr><td>Edit attributes (bulk bar)</td><td>Change type, scope, and classification for all selected documents in one step. Fields left at "Keep current" are not modified. Filename is per-document only; use the row's ✎ button instead.</td></tr>
               <tr><td>✕ (row)</td><td>Delete a document. Removes it from storage and the knowledge graph. Requires confirmation.</td></tr>
             </table>
             <div class="help-tip">Recommended workflow for a batch of new documents: Set the document type and classification → upload all files → use ✎ to adjust individual attributes if needed → click Index Documents to build the knowledge graph.</div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1600,6 +1600,73 @@ body { display: block; }
 
 .wb-actions { white-space: nowrap; }
 
+/* ── Bulk selection ──────────────────────────────────────────── */
+.wb-table th.wb-check-col,
+.wb-table td.wb-check-col {
+  width: 28px;
+  padding-right: 0;
+  text-align: center;
+}
+
+.wb-row-check,
+#wb-check-all {
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.wb-table tr.wb-row-selected td {
+  background: rgba(212, 160, 23, 0.06);
+}
+.wb-table tr.wb-row-selected:hover td {
+  background: rgba(212, 160, 23, 0.12);
+}
+
+.wb-bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  margin-bottom: 6px;
+  background: rgba(212, 160, 23, 0.08);
+  border: 1px solid rgba(212, 160, 23, 0.35);
+  border-radius: var(--radius);
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+.wb-bulk-bar .wb-bulk-count {
+  color: var(--text-muted);
+  margin-right: auto;
+}
+.wb-bulk-bar .wb-bulk-count strong { color: var(--gold); }
+
+.wb-bulk-target {
+  font-size: 0.82rem;
+  color: var(--text);
+  margin: 0 0 14px;
+  line-height: 1.5;
+}
+.wb-bulk-target em { color: var(--gold); font-style: italic; }
+.wb-bulk-target strong { color: var(--gold); }
+
+.wb-bulk-form {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px 12px;
+  align-items: center;
+}
+
+.wb-bulk-warning {
+  margin: 12px 0 0;
+  padding: 8px 10px;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: var(--radius);
+  color: #fca5a5;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
 .wb-chat-attach-btn {
   background: none;
   border: 1px solid rgba(64,184,255,0.30);


### PR DESCRIPTION
Closes #34

## Summary

Adds row-level selection checkboxes and a bulk-edit bar to the Workbench document table so the user can change doc type, scope, and classification for many documents at once without walking through each row's ✎ button.

- New first column with per-row checkboxes plus a header checkbox that toggles every row currently visible (respects the active scope + type filter).
- A sticky bulk-action bar appears above the table as soon as one row is checked, showing the count, an **Edit attributes** button, and a Clear button.
- **Edit attributes** opens a modal with Type / Scope / Classification selects; each defaults to a *Keep current* sentinel so only explicitly chosen fields are patched on each doc. A client-side warning blocks the specific invalid combo (moving to client/project scope with classification=public) that the `PATCH /api/documents/{id}` validator would otherwise 422 on.
- Each selected doc fires its own `PATCH` in parallel via the existing endpoint — no new API surface. Partial failures are surfaced in the modal status line with the first few error messages; the table reloads either way so successful updates are immediately visible.
- Filename is intentionally not part of bulk edit; README / help text point the user at the row ✎ button for per-document renames.

Docs updated: README.md feature bullet and the in-app HELP modal's Workbench table.

## Test results

- `cd api && python3 -m pytest` → 132 passed, 2 warnings (pre-existing `on_event` deprecation). Pure-frontend change; no backend behaviour altered.

**Visual verification pending — automated agent. Manual browser check required before merge.**