### PR TITLE
extractor: shared batch-status poller (#40)

### DIFF
--- a/api/extractor.py
+++ b/api/extractor.py
@@ -377,76 +377,93 @@ async def _submit_extract_batch_job(
         return None
 
 
-async def _poll_extract_batch_job(
-    client: httpx.AsyncClient,
-    job_id: str,
-) -> str | None:
+class _BatchPoller:
     """
-    Poll ``/api/batch/results/{job_id}`` until the job finishes.
+    Shared batch-job poller for one ``extract_chunks_batch`` run.
 
-    Returns the completed response text on success. Returns None if the job
-    fails, disappears, or does not complete within BATCH_POLL_MAX_SECONDS —
-    the extractor treats every "no result" case as a non-fatal empty
-    extraction, same as the pre-migration sync path.
+    One task issues ``GET /api/batch/status`` every BATCH_POLL_INTERVAL and
+    resolves per-job futures as each job reaches a terminal state. Replaces
+    the prior per-chunk poll loop that issued N concurrent
+    ``GET /api/batch/results/{id}`` calls — on a 100-chunk ingest merLLM
+    saw ~100 requests every 3 s, almost all returning 409 "still running"
+    (#40).
 
-    Status handling mirrors squire's reanalyze poller (parsival/api/
-    orchestrator.py::_poll_batch_once):
-      200            — completed; ``result`` field has the response text
-      409 queued/running — still in merLLM's queue; keep polling
-      409 failed     — merLLM gave up; treat as empty extraction
-      404            — job unknown to merLLM (DB wipe, race); give up
+    The status endpoint already contains ``result`` inline for completed
+    jobs, so no follow-up per-job GET is needed. It returns the 200
+    most-recent jobs (ordered by submitted_at DESC), which covers a typical
+    single-document extraction. If a job we just submitted isn't in the
+    response yet (rare — only possible if 200+ newer jobs landed in the
+    window), we simply keep waiting; the per-chunk BATCH_POLL_MAX_SECONDS
+    deadline is still the safety net.
     """
-    deadline = asyncio.get_event_loop().time() + BATCH_POLL_MAX_SECONDS
-    while asyncio.get_event_loop().time() < deadline:
-        try:
-            resp = await client.get(
-                f"{config.MERLLM_URL}/api/batch/results/{job_id}",
-                timeout=BATCH_SUBMIT_TIMEOUT,
-            )
-        except Exception as exc:
-            logger.warning(
-                "extractor: batch poll %s failed (%s: %s) — retrying",
-                job_id[:8], type(exc).__name__, exc or "<no message>",
-            )
+
+    def __init__(self, client: httpx.AsyncClient):
+        self._client  = client
+        self._pending: dict[str, asyncio.Future[str | None]] = {}
+        self._stopped = False
+
+    def register(self, job_id: str) -> asyncio.Future[str | None]:
+        fut = asyncio.get_running_loop().create_future()
+        self._pending[job_id] = fut
+        return fut
+
+    def unregister(self, job_id: str) -> None:
+        self._pending.pop(job_id, None)
+
+    def stop(self) -> None:
+        self._stopped = True
+
+    async def run(self) -> None:
+        while not self._stopped:
             await asyncio.sleep(BATCH_POLL_INTERVAL)
-            continue
+            if self._stopped:
+                break
+            if not self._pending:
+                continue
 
-        if resp.status_code == 200:
-            return resp.json().get("result", "")
-
-        if resp.status_code == 404:
-            logger.warning("extractor: batch job %s not found in merLLM", job_id[:8])
-            return None
-
-        if resp.status_code == 409:
-            detail = ""
             try:
-                detail = resp.json().get("detail", "")
-            except Exception:
-                pass
-            if "failed" in detail:
-                logger.warning("extractor: batch job %s failed in merLLM", job_id[:8])
-                return None
-            # queued or running — keep waiting.
-            await asyncio.sleep(BATCH_POLL_INTERVAL)
-            continue
+                resp = await self._client.get(
+                    f"{config.MERLLM_URL}/api/batch/status",
+                    timeout=BATCH_SUBMIT_TIMEOUT,
+                )
+                resp.raise_for_status()
+                jobs = resp.json()
+            except Exception as exc:
+                logger.warning(
+                    "extractor: shared batch poll failed (%s: %s) — retrying",
+                    type(exc).__name__, exc or "<no message>",
+                )
+                continue
 
-        # Any other status: log and retry briefly.
-        logger.warning(
-            "extractor: batch poll %s got %d — retrying",
-            job_id[:8], resp.status_code,
-        )
-        await asyncio.sleep(BATCH_POLL_INTERVAL)
+            by_id = {j.get("id"): j for j in jobs if j.get("id")}
+            for job_id in list(self._pending.keys()):
+                rec = by_id.get(job_id)
+                if rec is None:
+                    # Job not in the 200-most-recent window yet (or bumped
+                    # out by a very busy queue). Keep waiting — the
+                    # per-chunk deadline will eventually give up.
+                    continue
+                fut = self._pending.get(job_id)
+                if fut is None or fut.done():
+                    continue
 
-    logger.warning(
-        "extractor: batch job %s still not complete after %.0fs — giving up",
-        job_id[:8], BATCH_POLL_MAX_SECONDS,
-    )
-    return None
+                status = rec.get("status")
+                if status == "completed":
+                    fut.set_result(rec.get("result") or "")
+                    self._pending.pop(job_id, None)
+                elif status in ("failed", "cancelled"):
+                    logger.warning(
+                        "extractor: batch job %s reached terminal state %s",
+                        job_id[:8], status,
+                    )
+                    fut.set_result(None)
+                    self._pending.pop(job_id, None)
+                # else queued / running — keep waiting.
 
 
 async def _extract_one_via_batch(
     client: httpx.AsyncClient,
+    poller: "_BatchPoller",
     chunk: str,
     system_prompt: str,
     doc_type: str,
@@ -463,7 +480,17 @@ async def _extract_one_via_batch(
     if not job_id:
         return ExtractionResult()
 
-    response_text = await _poll_extract_batch_job(client, job_id)
+    fut = poller.register(job_id)
+    try:
+        response_text = await asyncio.wait_for(fut, BATCH_POLL_MAX_SECONDS)
+    except asyncio.TimeoutError:
+        poller.unregister(job_id)
+        logger.warning(
+            "extractor: batch job %s still not complete after %.0fs — giving up",
+            job_id[:8], BATCH_POLL_MAX_SECONDS,
+        )
+        return ExtractionResult()
+
     if not response_text:
         return ExtractionResult()
 
@@ -486,11 +513,11 @@ async def extract_chunks_batch(
     the pre-migration sync ``/api/chat`` path silently lost every in-flight
     chunk when merLLM was restarted. See hexcaliper#29 for the incident.
 
-    Submission runs in a single async session, and polls run concurrently
-    via ``asyncio.gather``: we pay one round-trip per chunk to submit, then
-    wait for results in parallel. merLLM itself serialises execution across
-    the BACKGROUND bucket, so concurrent polls do not stress the GPU — they
-    just mean we notice each completion as soon as it lands.
+    Submission runs in a single async session. A single shared poller task
+    (``_BatchPoller``) issues one ``GET /api/batch/status`` per poll
+    interval and resolves per-chunk futures as jobs reach terminal states —
+    O(1) request rate regardless of chunk concurrency (#40). merLLM itself
+    serialises execution across the BACKGROUND bucket.
 
     Per-chunk failure (submit error, poll timeout, merLLM-reported failure,
     JSON parse error) is non-fatal and yields an empty ``ExtractionResult``
@@ -510,14 +537,20 @@ async def extract_chunks_batch(
     m = model or _extract_model()
     system_prompt = _build_system_prompt(learned_vocab)
 
-    # One httpx session for submit + all polls — cheaper than reopening a
-    # client per chunk, and still fully async.
+    # One httpx session for submit + the shared status poll — cheaper than
+    # reopening a client per chunk, and still fully async.
     async with httpx.AsyncClient() as client:
-        tasks = [
-            _extract_one_via_batch(client, chunk, system_prompt, doc_type, m)
-            for chunk in chunks
-        ]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        poller = _BatchPoller(client)
+        poller_task = asyncio.create_task(poller.run())
+        try:
+            tasks = [
+                _extract_one_via_batch(client, poller, chunk, system_prompt, doc_type, m)
+                for chunk in chunks
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+        finally:
+            poller.stop()
+            await poller_task
 
     # gather with return_exceptions keeps the slot order intact even if one
     # coroutine blew up — map any exception to an empty result so callers

--- a/api/tests/test_extractor_batch.py
+++ b/api/tests/test_extractor_batch.py
@@ -6,7 +6,12 @@ endpoint (hexcaliper#29). Before the migration the extractor called
 merLLM's proxy ``/api/chat`` synchronously per chunk; merLLM did not
 persist those proxy calls, so a merLLM restart mid-ingest silently
 dropped graph edges for every in-flight chunk. These tests pin the new
-submit → poll → assemble contract and the fault-tolerance semantics.
+submit → shared-poll → assemble contract and the fault-tolerance
+semantics.
+
+The poll path is shared: one ``GET /api/batch/status`` resolves every
+in-flight job's future, instead of one ``GET /api/batch/results/{id}``
+per chunk per tick (#40).
 """
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,11 +31,12 @@ def _mock_submit_response(job_id: str = "job-abc"):
     return r
 
 
-def _mock_result_response(status_code: int, *, payload: dict | None = None):
+def _mock_status_response(jobs: list[dict]):
+    """Mirror merLLM's ``GET /api/batch/status`` — list of job dicts."""
     r = MagicMock()
-    r.status_code = status_code
+    r.status_code = 200
     r.raise_for_status = MagicMock()
-    r.json.return_value = payload or {}
+    r.json.return_value = jobs
     return r
 
 
@@ -42,6 +48,16 @@ def _valid_extraction_json() -> str:
         '"doc_role": "requirement", '
         '"key_assertion": "The SIF shall achieve SIL 2."}'
     )
+
+
+def _make_mock_client(fake_post, fake_get):
+    """Build an AsyncClient stand-in that returns our fake responses."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(side_effect=fake_post)
+    mock_client.get = AsyncMock(side_effect=fake_get)
+    return mock_client
 
 
 # ── Submission contract ──────────────────────────────────────────────────────
@@ -58,13 +74,14 @@ async def test_extract_chunks_batch_submits_to_merllm_batch_endpoint(monkeypatch
         return _mock_submit_response(f"job-{len(post_calls)}")
 
     async def fake_get(url, timeout=None, **kw):
-        return _mock_result_response(200, payload={"result": _valid_extraction_json()})
+        # Every submitted job appears as completed on the first poll.
+        return _mock_status_response([
+            {"id": f"job-{i}", "status": "completed",
+             "result": _valid_extraction_json()}
+            for i in range(1, len(post_calls) + 1)
+        ])
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.post = AsyncMock(side_effect=fake_post)
-    mock_client.get = AsyncMock(side_effect=fake_get)
+    mock_client = _make_mock_client(fake_post, fake_get)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(
@@ -95,13 +112,12 @@ async def test_extract_chunks_batch_flattens_messages_into_single_prompt(monkeyp
         return _mock_submit_response()
 
     async def fake_get(url, **kw):
-        return _mock_result_response(200, payload={"result": _valid_extraction_json()})
+        return _mock_status_response([
+            {"id": "job-abc", "status": "completed",
+             "result": _valid_extraction_json()},
+        ])
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.post = AsyncMock(side_effect=fake_post)
-    mock_client.get = AsyncMock(side_effect=fake_get)
+    mock_client = _make_mock_client(fake_post, fake_get)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         await extractor.extract_chunks_batch(["tell me about SIL 2"], doc_type="theop")
@@ -119,32 +135,78 @@ async def test_extract_chunks_batch_flattens_messages_into_single_prompt(monkeyp
 
 @pytest.mark.asyncio
 async def test_extract_chunks_batch_polls_until_complete(monkeypatch):
-    """A 409 queued/running response must not end the poll; we keep trying
-    until the job flips to 200 (completed)."""
+    """A queued/running status must not end the poll; we keep polling until
+    the job flips to completed."""
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
     get_count = {"n": 0}
 
     async def fake_post(url, json=None, **kw):
-        return _mock_submit_response()
+        return _mock_submit_response("job-abc")
 
     async def fake_get(url, **kw):
         get_count["n"] += 1
-        if get_count["n"] < 3:
-            return _mock_result_response(409, payload={"detail": "Job status: queued"})
-        return _mock_result_response(200, payload={"result": _valid_extraction_json()})
+        if get_count["n"] == 1:
+            return _mock_status_response([
+                {"id": "job-abc", "status": "queued", "result": None},
+            ])
+        if get_count["n"] == 2:
+            return _mock_status_response([
+                {"id": "job-abc", "status": "running", "result": None},
+            ])
+        return _mock_status_response([
+            {"id": "job-abc", "status": "completed",
+             "result": _valid_extraction_json()},
+        ])
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.post = AsyncMock(side_effect=fake_post)
-    mock_client.get = AsyncMock(side_effect=fake_get)
+    mock_client = _make_mock_client(fake_post, fake_get)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["only chunk"])
 
     assert len(results) == 1
     assert results[0].concepts == ["safety integrity level"]
-    assert get_count["n"] == 3  # polled through two queued states
+    assert get_count["n"] >= 3  # polled through queued + running before completed
+
+
+@pytest.mark.asyncio
+async def test_extract_chunks_batch_shared_poll_is_one_request_per_tick(monkeypatch):
+    """Regardless of concurrency, the poll path must issue exactly one
+    ``GET /api/batch/status`` per tick — not one per chunk (#40)."""
+    monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
+    status_calls = []
+    result_calls = []
+    submit_n = {"n": 0}
+
+    async def fake_post(url, json=None, **kw):
+        # 5 submits → 5 job ids.
+        submit_n["n"] += 1
+        return _mock_submit_response(f"job-{submit_n['n']}")
+
+    async def fake_get(url, **kw):
+        if url.endswith("/api/batch/status"):
+            status_calls.append(url)
+            return _mock_status_response([
+                {"id": f"job-{i}", "status": "completed",
+                 "result": _valid_extraction_json()}
+                for i in range(1, 6)
+            ])
+        # Any per-job GET would land here — a regression on the #40 fix.
+        result_calls.append(url)
+        return _mock_status_response([])
+
+    mock_client = _make_mock_client(fake_post, fake_get)
+
+    with patch("extractor.httpx.AsyncClient", return_value=mock_client):
+        results = await extractor.extract_chunks_batch(["a", "b", "c", "d", "e"])
+
+    assert len(results) == 5
+    assert all(not r.is_empty() for r in results)
+    # No per-job results endpoint calls — the shared /api/batch/status
+    # response already carries the result text.
+    assert result_calls == []
+    # Every chunk resolved from a small, bounded number of shared polls —
+    # emphatically not one poll per chunk per tick.
+    assert len(status_calls) <= 3
 
 
 # ── Fault tolerance — every failure mode returns empty, not an exception ────
@@ -160,13 +222,9 @@ async def test_extract_chunks_batch_submit_failure_yields_empty(monkeypatch):
         raise RuntimeError("merLLM unreachable")
 
     async def fake_get(url, **kw):
-        return _mock_result_response(200, payload={"result": _valid_extraction_json()})
+        return _mock_status_response([])
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.post = AsyncMock(side_effect=fake_post)
-    mock_client.get = AsyncMock(side_effect=fake_get)
+    mock_client = _make_mock_client(fake_post, fake_get)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["chunk"])
@@ -177,21 +235,20 @@ async def test_extract_chunks_batch_submit_failure_yields_empty(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_extract_chunks_batch_merllm_reported_failure_yields_empty(monkeypatch):
-    """merLLM returning 409 with 'failed' status must map to an empty
+    """A job that transitions to 'failed' in merLLM must map to an empty
     ExtractionResult — same contract as the pre-migration sync path."""
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
 
     async def fake_post(url, **kw):
-        return _mock_submit_response()
+        return _mock_submit_response("job-abc")
 
     async def fake_get(url, **kw):
-        return _mock_result_response(409, payload={"detail": "Job status: failed"})
+        return _mock_status_response([
+            {"id": "job-abc", "status": "failed", "result": None,
+             "error": "slot died"},
+        ])
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.post = AsyncMock(side_effect=fake_post)
-    mock_client.get = AsyncMock(side_effect=fake_get)
+    mock_client = _make_mock_client(fake_post, fake_get)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["chunk"])
@@ -201,22 +258,20 @@ async def test_extract_chunks_batch_merllm_reported_failure_yields_empty(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_extract_chunks_batch_404_yields_empty(monkeypatch):
-    """404 (job id unknown to merLLM, e.g. DB wiped between submit and poll)
-    must give up on that slot rather than poll forever."""
+async def test_extract_chunks_batch_missing_job_times_out_to_empty(monkeypatch):
+    """If a job never shows up in /api/batch/status (DB wipe, or pushed out
+    of the 200-window), the per-chunk deadline eventually returns empty —
+    no hang."""
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
+    monkeypatch.setattr(extractor, "BATCH_POLL_MAX_SECONDS", 0.05)
 
     async def fake_post(url, **kw):
-        return _mock_submit_response()
+        return _mock_submit_response("job-missing")
 
     async def fake_get(url, **kw):
-        return _mock_result_response(404)
+        return _mock_status_response([])  # our job never appears
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.post = AsyncMock(side_effect=fake_post)
-    mock_client.get = AsyncMock(side_effect=fake_get)
+    mock_client = _make_mock_client(fake_post, fake_get)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["chunk"])
@@ -232,25 +287,22 @@ async def test_extract_chunks_batch_preserves_slot_order_under_partial_failure(
     2 — callers rely on results[i] matching chunk_ids[i]."""
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
     submit_n = {"n": 0}
-    # Map each submit to a job id so we can route polls back.
-    job_map = {}
 
     async def fake_post(url, json=None, **kw):
         submit_n["n"] += 1
         if submit_n["n"] == 2:
             raise RuntimeError("simulated submit failure on chunk 2")
-        job_id = f"job-{submit_n['n']}"
-        job_map[job_id] = submit_n["n"]
-        return _mock_submit_response(job_id)
+        return _mock_submit_response(f"job-{submit_n['n']}")
 
     async def fake_get(url, **kw):
-        return _mock_result_response(200, payload={"result": _valid_extraction_json()})
+        return _mock_status_response([
+            {"id": "job-1", "status": "completed",
+             "result": _valid_extraction_json()},
+            {"id": "job-3", "status": "completed",
+             "result": _valid_extraction_json()},
+        ])
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.post = AsyncMock(side_effect=fake_post)
-    mock_client.get = AsyncMock(side_effect=fake_get)
+    mock_client = _make_mock_client(fake_post, fake_get)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["a", "b", "c"])


### PR DESCRIPTION
Closes #40

## Summary

- `extract_chunks_batch` previously spawned N per-chunk poll loops against `/api/batch/results/{job_id}`. With ~100 chunks in flight merLLM saw ~100 requests per 3 s tick, the vast majority returning 409 "still running."
- Replace the per-chunk loop with a single `_BatchPoller` task that issues one `GET /api/batch/status` per interval for the whole run. merLLM's status endpoint already carries the `result` text inline for completed jobs, so no per-job follow-up GET is needed — request rate is now **O(1) in chunk count**.
- `_extract_one_via_batch` submits, registers a future with the poller, and `await asyncio.wait_for(fut, BATCH_POLL_MAX_SECONDS)`. The existing `asyncio.gather` shape and per-slot ordering are preserved.
- Per-chunk deadline is kept as the safety net: if a job genuinely disappears from merLLM (DB wipe, 200-row status window eviction), the chunk still resolves to an empty `ExtractionResult` rather than hanging.

## Acceptance against the issue

- [x] Multi-chunk extraction produces negligible 409s on merLLM's `/api/batch/results/*` endpoint — **we stop hitting it entirely**. The shared poll lives on `/api/batch/status`, which returns 200.
- [x] Extraction throughput unchanged — first resolution latency is bounded by the same `BATCH_POLL_INTERVAL` (3 s default) as before.
- [x] Existing extractor tests updated to the new poll shape; a new test asserts 5 concurrent chunks resolve via ≤3 shared polls with 0 per-job GETs (the regression guard for #40).

## Test results

- `cd api && python3 -m pytest` → **133 passed**, 2 pre-existing deprecation warnings. New test: `test_extract_chunks_batch_shared_poll_is_one_request_per_tick`.