### PR TITLE
feat(chat): tag chat-path RAG embed with X-Priority: chat (#38)

### DIFF
--- a/api/rag.py
+++ b/api/rag.py
@@ -98,27 +98,38 @@ def chunk_text(text: str) -> list[str]:
 
 # ── Embedding ──────────────────────────────────────────────────
 
-async def embed(text: str) -> list[float]:
+async def embed(text: str, priority: Optional[str] = None) -> list[float]:
     """
     Generate a vector embedding for *text* using the Ollama embeddings API.
 
-    Routing: merLLM auto-classifies every ``/api/embeddings`` call into its
-    dedicated ``embeddings`` priority bucket regardless of any ``X-Priority``
-    header (merLLM#38). LanceLLMot's only responsibility is to tag the
-    request with ``X-Source: lancellmot`` so the merLLM dashboard can
-    attribute queue entries back to this app — that's all
-    :data:`config.EMBED_HEADERS` carries. Callers do not pick a priority
-    here and the function takes no header argument by design.
+    Routing: merLLM defaults every ``/api/embeddings`` call to its
+    dedicated ``embeddings`` priority bucket and only honors one
+    explicit override — ``X-Priority: chat`` routes the request to
+    ``chat`` so a chat-path RAG embed jumps ahead of ingest-chunk
+    embeds in the shared ``embeddings`` bucket (merLLM#58). LanceLLMot's
+    default stance is still "let merLLM decide" — the chat path opts in
+    by passing ``priority="chat"``; ingest keeps the default so bulk
+    chunk embeds stay in the ``embeddings`` bucket as before (merLLM#38).
 
     :param text: The text to embed.
     :type text: str
+    :param priority: Optional priority hint. When ``"chat"``, an
+        ``X-Priority: chat`` header is added for this request only —
+        the shared :data:`config.EMBED_HEADERS` dict is never mutated.
+        Any other value (including ``None``) sends the request with
+        source-tag only, landing it in merLLM's ``embeddings`` bucket.
+    :type priority: str | None
     :return: A list of floats representing the embedding vector.
     :rtype: list[float]
     :raises httpx.HTTPStatusError: If the Ollama API returns a non-2xx status.
     """
+    if priority == "chat":
+        headers = {**config.EMBED_HEADERS, "X-Priority": "chat"}
+    else:
+        headers = config.EMBED_HEADERS
     async with httpx.AsyncClient(
         timeout=120.0,
-        headers=config.EMBED_HEADERS,
+        headers=headers,
     ) as client:
         resp = await client.post(
             f"{config.OLLAMA_BASE_URL}/api/embeddings",
@@ -176,10 +187,11 @@ async def ingest(
 
     async def _bounded_embed(c: str) -> list[float]:
         async with sem:
-            # Routing is decided by merLLM: every /api/embeddings call lands
-            # in the dedicated embeddings bucket regardless of any header
-            # we send (merLLM#38). The semaphore here exists only to bound
-            # client-side concurrency to EMBED_CONCURRENCY.
+            # Ingest chunks stay in merLLM's default ``embeddings`` bucket —
+            # we deliberately don't pass ``priority`` here. Only the chat
+            # path opts into CHAT (merLLM#58 + lancellmot#38). The semaphore
+            # exists only to bound client-side concurrency to
+            # EMBED_CONCURRENCY.
             return await embed(c)
 
     # return_exceptions so one oversized chunk doesn't kill the whole upload —
@@ -408,6 +420,7 @@ async def search(
     top_k: int = TOP_K,
     scope_types: list[str] = None,
     scope_ids: list = None,
+    priority: Optional[str] = None,
 ) -> tuple[list[str], list[str], list[str], list[float], list[str]]:
     """
     Retrieve the most relevant document chunks for a query.
@@ -431,6 +444,12 @@ async def search(
     :param scope_ids: Parallel list of scope IDs corresponding to
         *scope_types*.  Use ``None`` for ``"global"`` entries.
     :type scope_ids: list | None
+    :param priority: Optional priority hint forwarded to :func:`embed`.
+        Chat callers pass ``"chat"`` so the query-vector embed routes
+        to merLLM's ``chat`` bucket and doesn't queue behind ingest-chunk
+        embeds (merLLM#58). Defaults to ``None`` → embed lands in the
+        ``embeddings`` bucket.
+    :type priority: str | None
     :return: A tuple of ``(text_chunks, doc_ids, chunk_ids, scores)`` for
         chunks that pass the distance threshold.  Scores are in [0, 1] with
         higher values indicating greater similarity. Anchors carry the
@@ -449,7 +468,7 @@ async def search(
     col = get_collection()
     if col.count() == 0:
         return [], [], [], [], []
-    query_emb = await embed(query)
+    query_emb = await embed(query, priority=priority)
 
     # Build the ChromaDB metadata filter.
     # Each (scope_type, scope_id) pair becomes one clause in a $or.

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -110,6 +110,7 @@ async def chat(req: ChatRequest, request: Request):
         doc_chunks, doc_ids, chunk_ids, chunk_scores, chunk_anchors = await rag.search(
             user_email, req.message,
             scope_types=scope_types, scope_ids=scope_ids,
+            priority="chat",
         )
     except Exception as exc:
         log.exception("RAG vector search failed, proceeding without document context")

--- a/api/tests/test_extractor_priority.py
+++ b/api/tests/test_extractor_priority.py
@@ -101,3 +101,116 @@ async def test_embed_sends_lancellmot_source():
     _, kwargs = mock_cls.call_args
     assert kwargs["headers"] is config.EMBED_HEADERS
     assert kwargs["headers"]["X-Source"] == "lancellmot"
+
+
+@pytest.mark.asyncio
+async def test_embed_with_chat_priority_adds_header():
+    """rag.embed(priority='chat') must add X-Priority: chat for that call.
+
+    lancellmot#38 + merLLM#58: the chat-path RAG query-vector embed is on
+    the critical path of an interactive response, so the caller opts into
+    the ``chat`` bucket. The shared config.EMBED_HEADERS must not be
+    mutated — the header override is per-call.
+    """
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"embedding": [0.0]}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("rag.httpx.AsyncClient", return_value=mock_client) as mock_cls:
+        await rag.embed("query text", priority="chat")
+
+    _, kwargs = mock_cls.call_args
+    headers = kwargs["headers"]
+    assert headers["X-Source"] == "lancellmot"
+    assert headers["X-Priority"] == "chat"
+    # Shared config dict stays clean — the override was per-call only.
+    assert "X-Priority" not in config.EMBED_HEADERS
+
+
+@pytest.mark.asyncio
+async def test_embed_without_priority_has_no_priority_header():
+    """Default rag.embed(text) must not carry X-Priority.
+
+    Ingest path uses the default and must stay in merLLM's ``embeddings``
+    bucket. Regression guard: if someone adds a default priority, ingest
+    would silently move to a different bucket.
+    """
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"embedding": [0.0]}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("rag.httpx.AsyncClient", return_value=mock_client) as mock_cls:
+        await rag.embed("chunk text")
+
+    _, kwargs = mock_cls.call_args
+    assert "X-Priority" not in kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_search_threads_priority_through_to_embed():
+    """rag.search(priority='chat') must forward the hint to embed().
+
+    Chat router calls rag.search(..., priority='chat'); search() only
+    threads through — if this breaks, the chat-path embed silently
+    reverts to the embeddings bucket.
+    """
+    with patch("rag.embed", new=AsyncMock(return_value=[0.0, 0.0])) as mock_embed, \
+         patch("rag.get_collection") as mock_get_col:
+        mock_col = MagicMock()
+        mock_col.count.return_value = 0   # short-circuit return path is fine
+        mock_get_col.return_value = mock_col
+        await rag.search(
+            user_email="u@example.com",
+            query="q",
+            scope_types=["global"],
+            scope_ids=[None],
+            priority="chat",
+        )
+
+    # embed was called either at query time or in the short-circuit path
+    # — only the short-circuit happens here because count==0, so embed
+    # is NOT called. Re-run with count>0 would be a ChromaDB-shaped
+    # integration test; the per-call hint is already pinned by
+    # test_embed_with_chat_priority_adds_header. We instead assert the
+    # function signature accepts the kwarg.
+    import inspect
+    sig = inspect.signature(rag.search)
+    assert "priority" in sig.parameters, (
+        "rag.search must accept a priority= kwarg so the chat router "
+        "can opt into X-Priority: chat for the query-vector embed"
+    )
+    assert sig.parameters["priority"].default is None, (
+        "rag.search priority must default to None so non-chat callers "
+        "(ingest, probes) keep landing in the embeddings bucket"
+    )
+
+
+def test_chat_router_calls_rag_search_with_chat_priority():
+    """routers/chat.py must pass priority='chat' to rag.search().
+
+    Source-level regression guard: if someone refactors the chat router
+    and drops the priority hint, the query-vector embed silently reverts
+    to the ``embeddings`` bucket (merLLM#58 / lancellmot#38). The chat
+    router source is inspected directly because mocking the full chat
+    endpoint requires a large fixture stack that isn't worth it for a
+    single kwarg.
+    """
+    import pathlib
+    chat_src = pathlib.Path(__file__).resolve().parents[1] / "routers" / "chat.py"
+    text = chat_src.read_text()
+    # The call to rag.search in the chat path must pass priority="chat".
+    assert 'priority="chat"' in text or "priority='chat'" in text, (
+        "routers/chat.py must call rag.search(..., priority='chat') so "
+        "the chat-path RAG embed jumps to merLLM's CHAT bucket "
+        "(merLLM#58 / lancellmot#38)"
+    )


### PR DESCRIPTION
Closes #38

Depends on rcanterberryhall/hexcaliper-merLLM#66 (merLLM#58) — merLLM must accept the header before this has any effect. Safe to merge either order, but both need to be live for the end-to-end chat-during-upload test to show improvement.

## Summary

- \`rag.embed(text, priority=None)\` — when ``priority=\"chat\"`` the outbound request carries ``X-Priority: chat`` alongside the existing ``X-Source: lancellmot`` tag. The shared ``config.EMBED_HEADERS`` dict is **not** mutated; the override is a per-call header merge.
- \`rag.search(..., priority=None)\` threads the hint through to ``embed``.
- ``routers/chat.py`` calls ``rag.search(..., priority=\"chat\")`` so the query-vector embed gating the chat response jumps to merLLM's CHAT bucket.
- Ingest path (``_bounded_embed``) keeps the default so bulk chunk embeds stay in the EMBEDDINGS bucket as before.

## Test results

Full suite locally: **137 passed** (``pytest -q``).

New tests in \`test_extractor_priority.py\`:
- \`test_embed_with_chat_priority_adds_header\` — priority='chat' adds X-Priority: chat, EMBED_HEADERS stays clean.
- \`test_embed_without_priority_has_no_priority_header\` — regression guard: default embed carries no X-Priority.
- \`test_search_threads_priority_through_to_embed\` — signature + default pinned.
- \`test_chat_router_calls_rag_search_with_chat_priority\` — source-level guard that ``routers/chat.py`` passes ``priority=\"chat\"``.

## Out of scope

- Escalation-cache embed paths (\`search_escalation_cache\` / \`store_escalation_cache\`) also live on the interactive chat path but are not tagged here — can follow up if they show the same queueing symptom.
- Does not address cross-bucket starvation when the embed model isn't resident — that's merLLM#59.

## Test plan after both PRs land

- [ ] Rebuild both merllm-api and lancellmot-api.
- [ ] Trigger a document upload; while chunk embeds are flowing, send a chat message.
- [ ] Verify in merLLM's live queue view that the chat-triggered embed shows ``priority: chat`` (bucket 0) while ingest-chunk embeds stay in ``priority: embeddings`` (bucket 1).
- [ ] Chat response should return promptly instead of hitting the 120s rag.embed timeout.