### PR TITLE
Extractor: merLLM owns the queue (#48)

### DIFF
--- a/api/extractor.py
+++ b/api/extractor.py
@@ -52,11 +52,17 @@ EXTRACT_TIMEOUT = float(config._get("EXTRACT_TIMEOUT_SECONDS", "120"))
 # silently drops graph edges for half a document.
 BATCH_SUBMIT_TIMEOUT = float(config._get("EXTRACT_BATCH_SUBMIT_TIMEOUT", "15"))
 BATCH_POLL_INTERVAL  = float(config._get("EXTRACT_BATCH_POLL_INTERVAL", "3"))
-# Overall wall-clock cap per chunk while polling for a result. qwen3:32b on a
-# P40 returns in well under a minute at BACKGROUND priority when the queue is
-# warm; 15 min is a generous ceiling that tolerates queue pile-ups without
-# letting a runaway poll leak forever.
-BATCH_POLL_MAX_SECONDS = float(config._get("EXTRACT_BATCH_POLL_MAX_SECONDS", "900"))
+
+# merLLM owns the lifetime of every accepted batch job — its slot-watchdog
+# (_sweep_busy_timeouts) already reclaims wedged GPU slots, so the client
+# has no business timing out a job that's merely waiting in queue. The only
+# legitimate "give up" signal is that merLLM no longer recognises the job
+# ID, meaning the row was manually drained / DB wiped / lost to a
+# downgrade. We detect that by asking for status-by-ids and counting
+# consecutive misses per job. /api/batch/submit writes the DB row before
+# returning the ID, so a miss on the very next poll is already suspicious;
+# 5 gives generous headroom against any transient DB-read anomaly.
+BATCH_MISS_TOLERANCE = int(config._get("EXTRACT_BATCH_MISS_TOLERANCE", "5"))
 
 # Cap on *learned* vocab entries fed into the system prompt on top of the
 # seeded CONCEPT_VOCAB. The learned set grows unbounded as documents are
@@ -381,34 +387,37 @@ class _BatchPoller:
     """
     Shared batch-job poller for one ``extract_chunks_batch`` run.
 
-    One task issues ``GET /api/batch/status`` every BATCH_POLL_INTERVAL and
-    resolves per-job futures as each job reaches a terminal state. Replaces
-    the prior per-chunk poll loop that issued N concurrent
+    One task issues ``POST /api/batch/status-by-ids`` every
+    BATCH_POLL_INTERVAL, passing the full set of still-pending job IDs,
+    and resolves per-job futures as each job reaches a terminal state.
+    Replaces the prior per-chunk poll loop that issued N concurrent
     ``GET /api/batch/results/{id}`` calls — on a 100-chunk ingest merLLM
     saw ~100 requests every 3 s, almost all returning 409 "still running"
     (#40).
 
-    The status endpoint already contains ``result`` inline for completed
-    jobs, so no follow-up per-job GET is needed. It returns the 200
-    most-recent jobs (ordered by submitted_at DESC), which covers a typical
-    single-document extraction. If a job we just submitted isn't in the
-    response yet (rare — only possible if 200+ newer jobs landed in the
-    window), we simply keep waiting; the per-chunk BATCH_POLL_MAX_SECONDS
-    deadline is still the safety net.
+    status-by-ids is explicitly scoped to our in-flight IDs, so it is
+    immune to the 200-row LIMIT on ``GET /api/batch/status`` — a
+    concurrent ingest from another client can no longer push our jobs
+    out of visibility. merLLM owns the job's lifetime; we only declare a
+    job lost if it drops out of merLLM's DB entirely for
+    ``BATCH_MISS_TOLERANCE`` consecutive polls (manual drain, DB wipe).
     """
 
     def __init__(self, client: httpx.AsyncClient):
         self._client  = client
         self._pending: dict[str, asyncio.Future[str | None]] = {}
+        self._misses:  dict[str, int] = {}
         self._stopped = False
 
     def register(self, job_id: str) -> asyncio.Future[str | None]:
         fut = asyncio.get_running_loop().create_future()
         self._pending[job_id] = fut
+        self._misses[job_id] = 0
         return fut
 
-    def unregister(self, job_id: str) -> None:
+    def _drop(self, job_id: str) -> None:
         self._pending.pop(job_id, None)
+        self._misses.pop(job_id, None)
 
     def stop(self) -> None:
         self._stopped = True
@@ -421,9 +430,11 @@ class _BatchPoller:
             if not self._pending:
                 continue
 
+            ids = list(self._pending.keys())
             try:
-                resp = await self._client.get(
-                    f"{config.MERLLM_URL}/api/batch/status",
+                resp = await self._client.post(
+                    f"{config.MERLLM_URL}/api/batch/status-by-ids",
+                    json={"ids": ids},
                     timeout=BATCH_SUBMIT_TIMEOUT,
                 )
                 resp.raise_for_status()
@@ -436,29 +447,37 @@ class _BatchPoller:
                 continue
 
             by_id = {j.get("id"): j for j in jobs if j.get("id")}
-            for job_id in list(self._pending.keys()):
-                rec = by_id.get(job_id)
-                if rec is None:
-                    # Job not in the 200-most-recent window yet (or bumped
-                    # out by a very busy queue). Keep waiting — the
-                    # per-chunk deadline will eventually give up.
-                    continue
+            for job_id in ids:
                 fut = self._pending.get(job_id)
                 if fut is None or fut.done():
                     continue
+                rec = by_id.get(job_id)
+                if rec is None:
+                    self._misses[job_id] = self._misses.get(job_id, 0) + 1
+                    if self._misses[job_id] >= BATCH_MISS_TOLERANCE:
+                        logger.warning(
+                            "extractor: batch job %s missing from merLLM "
+                            "after %d consecutive polls — giving up",
+                            job_id[:8], self._misses[job_id],
+                        )
+                        fut.set_result(None)
+                        self._drop(job_id)
+                    continue
 
+                # Job present → reset miss counter and check status.
+                self._misses[job_id] = 0
                 status = rec.get("status")
                 if status == "completed":
                     fut.set_result(rec.get("result") or "")
-                    self._pending.pop(job_id, None)
+                    self._drop(job_id)
                 elif status in ("failed", "cancelled"):
                     logger.warning(
                         "extractor: batch job %s reached terminal state %s",
                         job_id[:8], status,
                     )
                     fut.set_result(None)
-                    self._pending.pop(job_id, None)
-                # else queued / running — keep waiting.
+                    self._drop(job_id)
+                # else queued / running — keep waiting indefinitely.
 
 
 async def _extract_one_via_batch(
@@ -481,15 +500,10 @@ async def _extract_one_via_batch(
         return ExtractionResult()
 
     fut = poller.register(job_id)
-    try:
-        response_text = await asyncio.wait_for(fut, BATCH_POLL_MAX_SECONDS)
-    except asyncio.TimeoutError:
-        poller.unregister(job_id)
-        logger.warning(
-            "extractor: batch job %s still not complete after %.0fs — giving up",
-            job_id[:8], BATCH_POLL_MAX_SECONDS,
-        )
-        return ExtractionResult()
+    # No wall-clock deadline: merLLM owns the job's lifetime. The poller
+    # resolves the future only when merLLM reports a terminal status or
+    # forgets the job (BATCH_MISS_TOLERANCE misses in a row).
+    response_text = await fut
 
     if not response_text:
         return ExtractionResult()
@@ -544,7 +558,9 @@ async def extract_chunks_batch(
         poller_task = asyncio.create_task(poller.run())
         try:
             tasks = [
-                _extract_one_via_batch(client, poller, chunk, system_prompt, doc_type, m)
+                _extract_one_via_batch(
+                    client, poller, chunk, system_prompt, doc_type, m,
+                )
                 for chunk in chunks
             ]
             results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/api/tests/test_extractor_batch.py
+++ b/api/tests/test_extractor_batch.py
@@ -9,9 +9,11 @@ dropped graph edges for every in-flight chunk. These tests pin the new
 submit → shared-poll → assemble contract and the fault-tolerance
 semantics.
 
-The poll path is shared: one ``GET /api/batch/status`` resolves every
-in-flight job's future, instead of one ``GET /api/batch/results/{id}``
-per chunk per tick (#40).
+The poll path is shared: one ``POST /api/batch/status-by-ids`` carries
+every in-flight job ID per tick, instead of one
+``GET /api/batch/results/{id}`` per chunk per tick (#40). merLLM owns
+each job's lifetime — the client only gives up on a job if merLLM
+forgets it for BATCH_MISS_TOLERANCE consecutive polls (#48).
 """
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -32,7 +34,7 @@ def _mock_submit_response(job_id: str = "job-abc"):
 
 
 def _mock_status_response(jobs: list[dict]):
-    """Mirror merLLM's ``GET /api/batch/status`` — list of job dicts."""
+    """Mirror merLLM's ``POST /api/batch/status-by-ids`` — list of job dicts."""
     r = MagicMock()
     r.status_code = 200
     r.raise_for_status = MagicMock()
@@ -50,13 +52,19 @@ def _valid_extraction_json() -> str:
     )
 
 
-def _make_mock_client(fake_post, fake_get):
-    """Build an AsyncClient stand-in that returns our fake responses."""
+def _make_mock_client(fake_post):
+    """Build an AsyncClient stand-in. Both submit and status-by-ids are
+    POSTs, so tests supply a single ``fake_post`` that routes by URL."""
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.post = AsyncMock(side_effect=fake_post)
-    mock_client.get = AsyncMock(side_effect=fake_get)
+
+    async def _no_get(*a, **kw):
+        # Any GET would be a regression on the #40 fix (no per-job results
+        # polling) or the #48 refactor (status-by-ids is a POST).
+        raise AssertionError("extractor should not issue GETs in the batch path")
+    mock_client.get = AsyncMock(side_effect=_no_get)
     return mock_client
 
 
@@ -67,21 +75,21 @@ def _make_mock_client(fake_post, fake_get):
 async def test_extract_chunks_batch_submits_to_merllm_batch_endpoint(monkeypatch):
     """Every chunk must be POSTed to /api/batch/submit, not /api/chat."""
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
-    post_calls = []
+    submit_calls = []
 
     async def fake_post(url, json=None, timeout=None, **kw):
-        post_calls.append((url, json))
-        return _mock_submit_response(f"job-{len(post_calls)}")
+        if url.endswith("/api/batch/submit"):
+            submit_calls.append((url, json))
+            return _mock_submit_response(f"job-{len(submit_calls)}")
+        if url.endswith("/api/batch/status-by-ids"):
+            return _mock_status_response([
+                {"id": f"job-{i}", "status": "completed",
+                 "result": _valid_extraction_json()}
+                for i in range(1, len(submit_calls) + 1)
+            ])
+        raise AssertionError(f"unexpected POST {url}")
 
-    async def fake_get(url, timeout=None, **kw):
-        # Every submitted job appears as completed on the first poll.
-        return _mock_status_response([
-            {"id": f"job-{i}", "status": "completed",
-             "result": _valid_extraction_json()}
-            for i in range(1, len(post_calls) + 1)
-        ])
-
-    mock_client = _make_mock_client(fake_post, fake_get)
+    mock_client = _make_mock_client(fake_post)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(
@@ -89,12 +97,12 @@ async def test_extract_chunks_batch_submits_to_merllm_batch_endpoint(monkeypatch
         )
 
     assert len(results) == 2
-    # Both calls hit the batch submit endpoint.
-    assert all(url.endswith("/api/batch/submit") for url, _ in post_calls)
+    # Both submit calls hit the batch submit endpoint.
+    assert all(url.endswith("/api/batch/submit") for url, _ in submit_calls)
     # Source tag is lancellmot so merLLM can attribute queue entries.
-    assert all(body["source_app"] == "lancellmot" for _, body in post_calls)
+    assert all(body["source_app"] == "lancellmot" for _, body in submit_calls)
     # Defensive options are populated so qwen3:* cannot wedge a slot.
-    for _, body in post_calls:
+    for _, body in submit_calls:
         assert body["options"]["think"] is False
         assert body["options"]["num_predict"] > 0
         assert body["options"]["num_ctx"] >= 8192
@@ -108,16 +116,17 @@ async def test_extract_chunks_batch_flattens_messages_into_single_prompt(monkeyp
     submitted = []
 
     async def fake_post(url, json=None, **kw):
-        submitted.append(json["prompt"])
-        return _mock_submit_response()
+        if url.endswith("/api/batch/submit"):
+            submitted.append(json["prompt"])
+            return _mock_submit_response()
+        if url.endswith("/api/batch/status-by-ids"):
+            return _mock_status_response([
+                {"id": "job-abc", "status": "completed",
+                 "result": _valid_extraction_json()},
+            ])
+        raise AssertionError(f"unexpected POST {url}")
 
-    async def fake_get(url, **kw):
-        return _mock_status_response([
-            {"id": "job-abc", "status": "completed",
-             "result": _valid_extraction_json()},
-        ])
-
-    mock_client = _make_mock_client(fake_post, fake_get)
+    mock_client = _make_mock_client(fake_post)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         await extractor.extract_chunks_batch(["tell me about SIL 2"], doc_type="theop")
@@ -138,75 +147,100 @@ async def test_extract_chunks_batch_polls_until_complete(monkeypatch):
     """A queued/running status must not end the poll; we keep polling until
     the job flips to completed."""
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
-    get_count = {"n": 0}
+    poll_count = {"n": 0}
 
     async def fake_post(url, json=None, **kw):
-        return _mock_submit_response("job-abc")
-
-    async def fake_get(url, **kw):
-        get_count["n"] += 1
-        if get_count["n"] == 1:
+        if url.endswith("/api/batch/submit"):
+            return _mock_submit_response("job-abc")
+        if url.endswith("/api/batch/status-by-ids"):
+            poll_count["n"] += 1
+            if poll_count["n"] == 1:
+                return _mock_status_response([
+                    {"id": "job-abc", "status": "queued", "result": None},
+                ])
+            if poll_count["n"] == 2:
+                return _mock_status_response([
+                    {"id": "job-abc", "status": "running", "result": None},
+                ])
             return _mock_status_response([
-                {"id": "job-abc", "status": "queued", "result": None},
+                {"id": "job-abc", "status": "completed",
+                 "result": _valid_extraction_json()},
             ])
-        if get_count["n"] == 2:
-            return _mock_status_response([
-                {"id": "job-abc", "status": "running", "result": None},
-            ])
-        return _mock_status_response([
-            {"id": "job-abc", "status": "completed",
-             "result": _valid_extraction_json()},
-        ])
+        raise AssertionError(f"unexpected POST {url}")
 
-    mock_client = _make_mock_client(fake_post, fake_get)
+    mock_client = _make_mock_client(fake_post)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["only chunk"])
 
     assert len(results) == 1
     assert results[0].concepts == ["safety integrity level"]
-    assert get_count["n"] >= 3  # polled through queued + running before completed
+    assert poll_count["n"] >= 3  # polled through queued + running before completed
 
 
 @pytest.mark.asyncio
 async def test_extract_chunks_batch_shared_poll_is_one_request_per_tick(monkeypatch):
     """Regardless of concurrency, the poll path must issue exactly one
-    ``GET /api/batch/status`` per tick — not one per chunk (#40)."""
+    ``POST /api/batch/status-by-ids`` per tick — not one per chunk (#40)."""
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
-    status_calls = []
-    result_calls = []
     submit_n = {"n": 0}
+    status_calls = []
 
     async def fake_post(url, json=None, **kw):
-        # 5 submits → 5 job ids.
-        submit_n["n"] += 1
-        return _mock_submit_response(f"job-{submit_n['n']}")
-
-    async def fake_get(url, **kw):
-        if url.endswith("/api/batch/status"):
-            status_calls.append(url)
+        if url.endswith("/api/batch/submit"):
+            submit_n["n"] += 1
+            return _mock_submit_response(f"job-{submit_n['n']}")
+        if url.endswith("/api/batch/status-by-ids"):
+            status_calls.append(json.get("ids") if json else None)
             return _mock_status_response([
                 {"id": f"job-{i}", "status": "completed",
                  "result": _valid_extraction_json()}
                 for i in range(1, 6)
             ])
-        # Any per-job GET would land here — a regression on the #40 fix.
-        result_calls.append(url)
-        return _mock_status_response([])
+        raise AssertionError(f"unexpected POST {url}")
 
-    mock_client = _make_mock_client(fake_post, fake_get)
+    mock_client = _make_mock_client(fake_post)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["a", "b", "c", "d", "e"])
 
     assert len(results) == 5
     assert all(not r.is_empty() for r in results)
-    # No per-job results endpoint calls — the shared /api/batch/status
-    # response already carries the result text.
-    assert result_calls == []
     # Every chunk resolved from a small, bounded number of shared polls —
     # emphatically not one poll per chunk per tick.
     assert len(status_calls) <= 3
+
+
+@pytest.mark.asyncio
+async def test_extract_chunks_batch_poll_sends_all_pending_ids(monkeypatch):
+    """Each shared poll must include every still-pending job ID in the
+    status-by-ids body — omitting one would silently hang that chunk."""
+    monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
+    submit_n = {"n": 0}
+    seen_ids_per_poll: list[set[str]] = []
+
+    async def fake_post(url, json=None, **kw):
+        if url.endswith("/api/batch/submit"):
+            submit_n["n"] += 1
+            return _mock_submit_response(f"job-{submit_n['n']}")
+        if url.endswith("/api/batch/status-by-ids"):
+            seen_ids_per_poll.append(set(json["ids"]))
+            return _mock_status_response([
+                {"id": f"job-{i}", "status": "completed",
+                 "result": _valid_extraction_json()}
+                for i in range(1, 4)
+            ])
+        raise AssertionError(f"unexpected POST {url}")
+
+    mock_client = _make_mock_client(fake_post)
+
+    with patch("extractor.httpx.AsyncClient", return_value=mock_client):
+        await extractor.extract_chunks_batch(["a", "b", "c"])
+
+    # The first poll that occurred after all 3 submits landed must have
+    # carried every ID.
+    expected = {"job-1", "job-2", "job-3"}
+    assert any(expected.issubset(ids) for ids in seen_ids_per_poll)
 
 
 # ── Fault tolerance — every failure mode returns empty, not an exception ────
@@ -219,12 +253,13 @@ async def test_extract_chunks_batch_submit_failure_yields_empty(monkeypatch):
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
 
     async def fake_post(url, **kw):
-        raise RuntimeError("merLLM unreachable")
+        if url.endswith("/api/batch/submit"):
+            raise RuntimeError("merLLM unreachable")
+        if url.endswith("/api/batch/status-by-ids"):
+            return _mock_status_response([])
+        raise AssertionError(f"unexpected POST {url}")
 
-    async def fake_get(url, **kw):
-        return _mock_status_response([])
-
-    mock_client = _make_mock_client(fake_post, fake_get)
+    mock_client = _make_mock_client(fake_post)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["chunk"])
@@ -240,15 +275,16 @@ async def test_extract_chunks_batch_merllm_reported_failure_yields_empty(monkeyp
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
 
     async def fake_post(url, **kw):
-        return _mock_submit_response("job-abc")
+        if url.endswith("/api/batch/submit"):
+            return _mock_submit_response("job-abc")
+        if url.endswith("/api/batch/status-by-ids"):
+            return _mock_status_response([
+                {"id": "job-abc", "status": "failed", "result": None,
+                 "error": "slot died"},
+            ])
+        raise AssertionError(f"unexpected POST {url}")
 
-    async def fake_get(url, **kw):
-        return _mock_status_response([
-            {"id": "job-abc", "status": "failed", "result": None,
-             "error": "slot died"},
-        ])
-
-    mock_client = _make_mock_client(fake_post, fake_get)
+    mock_client = _make_mock_client(fake_post)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["chunk"])
@@ -258,26 +294,68 @@ async def test_extract_chunks_batch_merllm_reported_failure_yields_empty(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_extract_chunks_batch_missing_job_times_out_to_empty(monkeypatch):
-    """If a job never shows up in /api/batch/status (DB wipe, or pushed out
-    of the 200-window), the per-chunk deadline eventually returns empty —
-    no hang."""
+async def test_extract_chunks_batch_missing_job_gives_up_after_miss_tolerance(
+        monkeypatch):
+    """If merLLM consistently reports the job as unknown (manual drain, DB
+    wipe) the poller gives up after BATCH_MISS_TOLERANCE polls — no hang.
+    Unlike the old wall-clock deadline, a queued-but-known job is never
+    abandoned."""
     monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
-    monkeypatch.setattr(extractor, "BATCH_POLL_MAX_SECONDS", 0.05)
+    monkeypatch.setattr(extractor, "BATCH_MISS_TOLERANCE", 3)
+    poll_count = {"n": 0}
 
     async def fake_post(url, **kw):
-        return _mock_submit_response("job-missing")
+        if url.endswith("/api/batch/submit"):
+            return _mock_submit_response("job-missing")
+        if url.endswith("/api/batch/status-by-ids"):
+            poll_count["n"] += 1
+            return _mock_status_response([])  # never returned by merLLM
+        raise AssertionError(f"unexpected POST {url}")
 
-    async def fake_get(url, **kw):
-        return _mock_status_response([])  # our job never appears
-
-    mock_client = _make_mock_client(fake_post, fake_get)
+    mock_client = _make_mock_client(fake_post)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["chunk"])
 
     assert len(results) == 1
     assert results[0].is_empty()
+    assert poll_count["n"] >= 3  # took at least BATCH_MISS_TOLERANCE misses
+
+
+@pytest.mark.asyncio
+async def test_extract_chunks_batch_does_not_give_up_while_job_is_queued(
+        monkeypatch):
+    """A job that stays ``queued`` for many polls must not be abandoned —
+    merLLM owns the lifetime. Proves there's no client-side wall-clock
+    deadline anymore (the defining bug behind #48)."""
+    monkeypatch.setattr(extractor, "BATCH_POLL_INTERVAL", 0.0)
+    monkeypatch.setattr(extractor, "BATCH_MISS_TOLERANCE", 3)
+    poll_count = {"n": 0}
+
+    async def fake_post(url, **kw):
+        if url.endswith("/api/batch/submit"):
+            return _mock_submit_response("job-slow")
+        if url.endswith("/api/batch/status-by-ids"):
+            poll_count["n"] += 1
+            # Stay queued for 10 polls (4× miss-tolerance), then complete.
+            if poll_count["n"] < 10:
+                return _mock_status_response([
+                    {"id": "job-slow", "status": "queued", "result": None},
+                ])
+            return _mock_status_response([
+                {"id": "job-slow", "status": "completed",
+                 "result": _valid_extraction_json()},
+            ])
+        raise AssertionError(f"unexpected POST {url}")
+
+    mock_client = _make_mock_client(fake_post)
+
+    with patch("extractor.httpx.AsyncClient", return_value=mock_client):
+        results = await extractor.extract_chunks_batch(["chunk"])
+
+    assert len(results) == 1
+    assert not results[0].is_empty()
+    assert poll_count["n"] >= 10
 
 
 @pytest.mark.asyncio
@@ -289,20 +367,21 @@ async def test_extract_chunks_batch_preserves_slot_order_under_partial_failure(
     submit_n = {"n": 0}
 
     async def fake_post(url, json=None, **kw):
-        submit_n["n"] += 1
-        if submit_n["n"] == 2:
-            raise RuntimeError("simulated submit failure on chunk 2")
-        return _mock_submit_response(f"job-{submit_n['n']}")
+        if url.endswith("/api/batch/submit"):
+            submit_n["n"] += 1
+            if submit_n["n"] == 2:
+                raise RuntimeError("simulated submit failure on chunk 2")
+            return _mock_submit_response(f"job-{submit_n['n']}")
+        if url.endswith("/api/batch/status-by-ids"):
+            return _mock_status_response([
+                {"id": "job-1", "status": "completed",
+                 "result": _valid_extraction_json()},
+                {"id": "job-3", "status": "completed",
+                 "result": _valid_extraction_json()},
+            ])
+        raise AssertionError(f"unexpected POST {url}")
 
-    async def fake_get(url, **kw):
-        return _mock_status_response([
-            {"id": "job-1", "status": "completed",
-             "result": _valid_extraction_json()},
-            {"id": "job-3", "status": "completed",
-             "result": _valid_extraction_json()},
-        ])
-
-    mock_client = _make_mock_client(fake_post, fake_get)
+    mock_client = _make_mock_client(fake_post)
 
     with patch("extractor.httpx.AsyncClient", return_value=mock_client):
         results = await extractor.extract_chunks_batch(["a", "b", "c"])

--- a/web/app.js
+++ b/web/app.js
@@ -1286,11 +1286,17 @@ async function pollMerllm() {
     const anyFaulted = Object.values(gpus).some(g => g.health === 'faulted');
     const health = allHealthy ? 'healthy' : anyFaulted ? 'faulted' : 'degraded';
     dot.className = 'merllm-dot ' + health;
-    const queued   = d.queue?.total ?? 0;
-    const inflight = d.queue?.in_flight ?? 0;
-    const active   = queued + inflight;
-    label.textContent = 'merLLM' + (active > 0 ? ` (${active})` : '');
-    label.title = `Routing: ${d.routing || 'round_robin'}` + (d.warnings?.length ? '\n⚠ ' + d.warnings.join('\n⚠ ') : '');
+    // Show active/queued as two separate numbers so the user can see queue
+    // depth even when both GPUs are saturated. "active" = jobs on a GPU
+    // right now; "queued" = jobs waiting in merLLM's SQLite queue. Prior
+    // build summed the two, which made a 435-deep backlog indistinguishable
+    // from a quiet system with 2 in flight.
+    const active = d.queue?.running ?? 0;
+    const queued = d.queue?.queued  ?? 0;
+    const badge  = (active > 0 || queued > 0) ? ` (${active}/${queued})` : '';
+    label.textContent = 'merLLM' + badge;
+    const tip = `Active ${active} / Queued ${queued} — routing: ${d.routing || 'round_robin'}`;
+    label.title = tip + (d.warnings?.length ? '\n⚠ ' + d.warnings.join('\n⚠ ') : '');
     if (d.warnings?.length) {
       dot.style.boxShadow = '0 0 0 2px rgba(210,153,34,.4)';
     } else {


### PR DESCRIPTION
## Summary
- Remove client-side wall-clock deadline on batch jobs (`BATCH_POLL_MAX_SECONDS`, `asyncio.wait_for`).
- Remove in-flight concurrency cap (`BATCH_MAX_IN_FLIGHT` semaphore) that was a band-aid for the deadline.
- `_BatchPoller` now POSTs the full pending-ID set to `/api/batch/status-by-ids` each tick (requires rcanterberryhall/hexcaliper-merLLM#71) and resolves futures only on terminal status or after `BATCH_MISS_TOLERANCE=5` consecutive polls where merLLM reports the job as unknown.
- Top-page merLLM button shows `(active/queued)` instead of summing them.

## Why
merLLM already owns each batch job's lifetime via its SQLite queue + `_sweep_busy_timeouts` slot watchdog. A client-side wall-clock deadline on a queued job is a footgun: if the queue gets deep (observed: 9k jobs during a reindex the morning of 2026-04-19), every chunk past the first ~210 would time out on the client while merLLM continued burning ~15 min of GPU per chunk producing a result nobody was listening for. The in-flight cap then became necessary to keep queue depth within the deadline — but that just reintroduced the dual-bucket accounting the April 9 GPU queue unification had eliminated.

The fix is to stop timing out on queue-wait entirely. The only legitimate "give up" signal is that merLLM no longer recognises the job ID (manual drain, DB wipe). Presence-based cancellation via the new status-by-ids endpoint is the clean shape.

## Test plan
- [x] `test_extractor_batch.py` — 11/11 pass
  - rewrote `missing_job_times_out_to_empty` → `missing_job_gives_up_after_miss_tolerance` (presence semantics)
  - new `does_not_give_up_while_job_is_queued` proves no wall-clock abandonment
  - `shared_poll_is_one_request_per_tick` now exercises POST status-by-ids
  - `poll_sends_all_pending_ids` verifies no ID is silently dropped from the poll body
- [x] `test_extractor_priority.py` + `test_extractor_prompt_cap.py` — 13/13 pass (no collateral)
- [x] Rebuilt container; extractor reachable
- [x] Top-button shows `merLLM (active/queued)`

## Blocked by
- rcanterberryhall/hexcaliper-merLLM#71 (new endpoint must be live before this merges)