### PR TITLE
docs/reindex: async run with run_id + progress endpoint + UI bar (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,8 @@ Interactive docs: `http://localhost:8000/docs`
 | `POST` | `/documents` | Upload a document (returns once chunks are embedded and searchable; summary, copyright notices, and concept-graph indexing finish asynchronously in the background) |
 | `PATCH` | `/documents/{id}` | Edit document attributes (filename, doc_type, classification) |
 | `DELETE` | `/documents/{id}` | Delete a document |
-| `POST` | `/documents/reindex` | Re-run concept extraction on all documents |
+| `POST` | `/documents/reindex` | Kick off a background reindex run; returns a `run_id` immediately. Idempotent per user — a second call while a run is active returns the same `run_id`. |
+| `GET` | `/documents/reindex/status` | Progress for a reindex run. With `?run_id=…` returns that exact run; without, returns the calling user's most recent run. |
 
 ### Workspace (Clients & Projects)
 

--- a/api/routers/documents.py
+++ b/api/routers/documents.py
@@ -47,6 +47,21 @@ def active_upload_snapshot() -> list[dict]:
     )
 
 
+# ── Reindex run tracking ──────────────────────────────────────────────────────
+# Maps run_id → run state (see _new_reindex_run for shape). Single async event
+# loop — no lock needed. State is in-memory; a process restart drops history,
+# matching the issue's scope decision (a killed reindex was already
+# unrecoverable, so persistence buys nothing here).
+_reindex_runs:    dict[str, dict] = {}
+_user_active_run: dict[str, str]  = {}     # user_email → run_id, while running
+
+# Rolling window for ETA: keep at most this many (timestamp, chunks_done)
+# samples per run, dropping anything older than RATE_WINDOW_SEC. Two minutes
+# of samples is enough to smooth one merLLM batch's worth of completions.
+RATE_WINDOW_SEC   = 120.0
+RATE_MAX_SAMPLES  = 60
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -464,15 +479,176 @@ async def delete_document(doc_id: str, request: Request):
     return Response(status_code=204)
 
 
+def _reindex_public_view(state: dict) -> dict:
+    """Strip task handle / internal samples before serializing to the client."""
+    eta = _reindex_eta_seconds(state)
+    return {
+        "run_id":           state["run_id"],
+        "status":           state["status"],
+        "started_at":       state["started_at"],
+        "completed_at":     state.get("completed_at"),
+        "scope":            state["scope"],
+        "docs_total":       state["docs_total"],
+        "docs_done":        state["docs_done"],
+        "chunks_total":     state["chunks_total"],
+        "chunks_done":      state["chunks_done"],
+        "current_doc":      state.get("current_doc"),
+        "eta_seconds":      eta,
+        "error":            state.get("error"),
+    }
+
+
+def _reindex_eta_seconds(state: dict) -> Optional[int]:
+    """Best-effort ETA from the rolling rate window. Returns None until enough
+    samples are collected or once the run has stopped."""
+    if state["status"] != "running":
+        return None
+    samples = state.get("rate_samples") or []
+    if len(samples) < 2:
+        return None
+    chunks_remaining = state["chunks_total"] - state["chunks_done"]
+    if chunks_remaining <= 0:
+        return 0
+    t0, c0 = samples[0]
+    t1, c1 = samples[-1]
+    elapsed = t1 - t0
+    delta   = c1 - c0
+    if elapsed <= 0 or delta <= 0:
+        return None
+    rate = delta / elapsed                  # chunks per second
+    return int(chunks_remaining / rate)
+
+
+def _record_progress_sample(state: dict) -> None:
+    """Append a (timestamp, chunks_done) sample, prune entries older than the
+    rolling window. Called every time chunks_done advances."""
+    now = time.time()
+    samples = state.setdefault("rate_samples", [])
+    samples.append((now, state["chunks_done"]))
+    cutoff = now - RATE_WINDOW_SEC
+    while samples and samples[0][0] < cutoff:
+        samples.pop(0)
+    if len(samples) > RATE_MAX_SAMPLES:
+        del samples[: len(samples) - RATE_MAX_SAMPLES]
+
+
+async def _perform_reindex(run_id: str, user_email: str,
+                           project_id: Optional[str],
+                           client_id:  Optional[str]) -> None:
+    """Background worker for one reindex run. Updates _reindex_runs[run_id]
+    in place; never raises (errors are recorded on the state)."""
+    state = _reindex_runs[run_id]
+    try:
+        with db.lock:
+            if project_id:
+                docs = db.list_documents_for_scope(user_email, ["project"], [project_id])
+            elif client_id:
+                docs = db.list_documents_for_scope(user_email, ["client"], [client_id])
+            else:
+                docs = db.list_all_documents(user_email)
+
+        # Pre-scan chunk counts so the progress bar shows a stable denominator
+        # from the first poll. ChromaDB lookup is cheap relative to extraction.
+        chunks_by_doc: dict[str, list[tuple[str, str]]] = {
+            doc["id"]: list(rag.get_doc_chunks(doc["id"])) for doc in docs
+        }
+        state["docs_total"]   = len(docs)
+        state["chunks_total"] = sum(len(v) for v in chunks_by_doc.values())
+        _record_progress_sample(state)
+
+        for doc in docs:
+            doc_id     = doc["id"]
+            scope_type = doc.get("scope_type", "global")
+            scope_id   = doc.get("scope_id") or None
+            doc_type   = doc.get("doc_type", "")
+
+            chunk_pairs       = chunks_by_doc[doc_id]
+            chunk_ids_for_doc = [cid for cid, _ in chunk_pairs]
+            chunk_texts       = [text for _, text in chunk_pairs]
+
+            state["current_doc"] = {
+                "id":           doc_id,
+                "title":        doc.get("filename", doc_id),
+                "chunks_total": len(chunk_pairs),
+                "chunks_done":  0,
+            }
+
+            # Build scoped vocabulary — same hierarchy as ingest().
+            vocab_scope_types: list[str]        = ["global"]
+            vocab_scope_ids:   list[Optional[str]] = [None]
+            if scope_type == "client" and scope_id:
+                vocab_scope_types.append("client")
+                vocab_scope_ids.append(scope_id)
+            elif scope_type == "project" and scope_id:
+                vocab_scope_types.append("project")
+                vocab_scope_ids.append(scope_id)
+                proj = db.get_project(scope_id)
+                if proj and proj.get("client_id"):
+                    vocab_scope_types.append("client")
+                    vocab_scope_ids.append(proj["client_id"])
+            elif scope_type == "session" and scope_id:
+                vocab_scope_types.append("session")
+                vocab_scope_ids.append(scope_id)
+
+            with db.lock:
+                learned_vocab = db.list_concept_vocab(
+                    vocab_scope_types, vocab_scope_ids, limit=extractor.MAX_LEARNED_VOCAB,
+                )
+
+            # Routes through merLLM's durable batch queue (hexcaliper#29) so
+            # an mid-reindex restart resumes instead of truncating the graph.
+            results = await extractor.extract_chunks_batch(
+                chunk_texts, doc_type=doc_type, learned_vocab=learned_vocab,
+            )
+            for chunk_id, result in zip(chunk_ids_for_doc, results):
+                if not result.is_empty():
+                    graph.index_chunk_concepts(
+                        chunk_id,
+                        concepts=result.concepts,
+                        entities=result.entities,
+                        doc_role=result.doc_role,
+                        key_assertion=result.key_assertion,
+                        scope_type=scope_type,
+                        scope_id=scope_id,
+                    )
+                state["chunks_done"] += 1
+                state["current_doc"]["chunks_done"] += 1
+
+            state["docs_done"] += 1
+            _record_progress_sample(state)
+
+        state["status"]       = "completed"
+        state["completed_at"] = _now_iso()
+        state["current_doc"]  = None
+    except Exception as exc:
+        log.exception("reindex run %s failed", run_id)
+        state["status"]       = "failed"
+        state["error"]        = f"{type(exc).__name__}: {exc}"
+        state["completed_at"] = _now_iso()
+    finally:
+        # Free the per-user idempotency slot whether we succeeded or failed,
+        # so the user can retry without restarting the process.
+        if _user_active_run.get(user_email) == run_id:
+            _user_active_run.pop(user_email, None)
+
+
 @router.post("/documents/reindex")
 async def reindex_documents(
-    request:    Request,
-    project_id: Optional[str] = None,
-    client_id:  Optional[str] = None,
+    request:          Request,
+    background_tasks: BackgroundTasks,
+    project_id:       Optional[str] = None,
+    client_id:        Optional[str] = None,
 ):
     """
-    Re-run concept extraction on all existing document chunks using the current
-    vocabulary, back-propagating newly learned keywords to older documents.
+    Kick off concept-extraction reindex as a background task and return
+    immediately with a ``run_id``. Poll ``GET /documents/reindex/status?run_id=…``
+    for progress.
+
+    Idempotent per user — if a run is already active for this user, the
+    existing ``run_id`` is returned and no second run is started. The
+    ``project_id`` / ``client_id`` filters of the existing run are NOT
+    overridden by a second call; cancel + retry would be needed for that
+    (out of scope for v1).
 
     Without query params: reindexes all documents owned by this user.
     With ``project_id``: only that project's documents.
@@ -480,72 +656,68 @@ async def reindex_documents(
     """
     user_email = _user(request)
 
-    with db.lock:
-        if project_id:
-            docs = db.list_documents_for_scope(user_email, ["project"], [project_id])
-        elif client_id:
-            docs = db.list_documents_for_scope(user_email, ["client"], [client_id])
-        else:
-            docs = db.list_all_documents(user_email)
+    existing_run_id = _user_active_run.get(user_email)
+    if existing_run_id and existing_run_id in _reindex_runs:
+        return _reindex_public_view(_reindex_runs[existing_run_id])
 
-    docs_processed   = 0
-    chunks_processed = 0
+    run_id = str(uuid.uuid4())
+    state  = {
+        "run_id":       run_id,
+        "user_email":   user_email,
+        "status":       "running",
+        "started_at":   _now_iso(),
+        "completed_at": None,
+        "scope": {
+            "project_id": project_id,
+            "client_id":  client_id,
+        },
+        "docs_total":   0,
+        "docs_done":    0,
+        "chunks_total": 0,
+        "chunks_done":  0,
+        "current_doc":  None,
+        "rate_samples": [],
+        "error":        None,
+    }
+    _reindex_runs[run_id]      = state
+    _user_active_run[user_email] = run_id
 
-    for doc in docs:
-        doc_id     = doc["id"]
-        scope_type = doc.get("scope_type", "global")
-        scope_id   = doc.get("scope_id") or None
-        doc_type   = doc.get("doc_type", "")
+    background_tasks.add_task(_perform_reindex, run_id, user_email, project_id, client_id)
 
-        # Build scoped vocabulary — same hierarchy as ingest().
-        vocab_scope_types: list[str]        = ["global"]
-        vocab_scope_ids:   list[Optional[str]] = [None]
-        if scope_type == "client" and scope_id:
-            vocab_scope_types.append("client")
-            vocab_scope_ids.append(scope_id)
-        elif scope_type == "project" and scope_id:
-            vocab_scope_types.append("project")
-            vocab_scope_ids.append(scope_id)
-            proj = db.get_project(scope_id)
-            if proj and proj.get("client_id"):
-                vocab_scope_types.append("client")
-                vocab_scope_ids.append(proj["client_id"])
-        elif scope_type == "session" and scope_id:
-            vocab_scope_types.append("session")
-            vocab_scope_ids.append(scope_id)
+    return _reindex_public_view(state)
 
-        with db.lock:
-            learned_vocab = db.list_concept_vocab(
-                vocab_scope_types, vocab_scope_ids, limit=extractor.MAX_LEARNED_VOCAB,
-            )
 
-        # Collect all chunks for the doc, then route the extraction through
-        # merLLM's durable batch queue (hexcaliper#29). A restart mid-reindex
-        # used to silently truncate the concept graph for every document
-        # still being processed — the batch path persists each chunk in
-        # merLLM's SQLite so it resumes after restart instead.
-        chunk_pairs       = list(rag.get_doc_chunks(doc_id))
-        chunk_ids_for_doc = [cid for cid, _ in chunk_pairs]
-        chunk_texts       = [text for _, text in chunk_pairs]
-        results           = await extractor.extract_chunks_batch(
-            chunk_texts, doc_type=doc_type, learned_vocab=learned_vocab,
-        )
-        for chunk_id, result in zip(chunk_ids_for_doc, results):
-            if not result.is_empty():
-                graph.index_chunk_concepts(
-                    chunk_id,
-                    concepts=result.concepts,
-                    entities=result.entities,
-                    doc_role=result.doc_role,
-                    key_assertion=result.key_assertion,
-                    scope_type=scope_type,
-                    scope_id=scope_id,
-                )
-            chunks_processed += 1
+@router.get("/documents/reindex/status")
+async def reindex_status(
+    request: Request,
+    run_id:  Optional[str] = None,
+):
+    """
+    Return progress for a reindex run. With ``run_id``: that exact run.
+    Without: the calling user's most recent run (active or last finished).
+    Returns 404 if neither exists.
+    """
+    user_email = _user(request)
 
-        docs_processed += 1
+    if run_id is None:
+        run_id = _user_active_run.get(user_email)
+        if not run_id:
+            # Fall back to the most recent finished run for this user, so a
+            # client that polls just after completion still sees the result.
+            user_runs = [s for s in _reindex_runs.values()
+                         if s.get("user_email") == user_email]
+            if not user_runs:
+                raise HTTPException(status_code=404, detail="No reindex runs for user.")
+            user_runs.sort(key=lambda s: s["started_at"], reverse=True)
+            run_id = user_runs[0]["run_id"]
 
-    return {"ok": True, "docs_reindexed": docs_processed, "chunks_processed": chunks_processed}
+    state = _reindex_runs.get(run_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Unknown run_id.")
+    if state.get("user_email") != user_email:
+        # Don't leak run state across users.
+        raise HTTPException(status_code=404, detail="Unknown run_id.")
+    return _reindex_public_view(state)
 
 
 @router.post("/documents/migrate-concept-scope")

--- a/api/tests/test_documents_router.py
+++ b/api/tests/test_documents_router.py
@@ -208,3 +208,96 @@ def test_download_document_404_when_bytes_missing(app_client):
     os.unlink(os.path.join(config.UPLOADS_PATH, doc["id"]))
     r = app_client.get(f"/documents/{doc['id']}/download")
     assert r.status_code == 404
+
+
+# ── POST /documents/reindex + GET /documents/reindex/status ───────────────────
+
+@pytest.fixture
+def clean_reindex_state():
+    """Wipe module-level reindex tracking dicts before and after each test —
+    they persist across the in-process app, which would otherwise leak runs
+    between tests."""
+    from routers import documents as docs_router
+    docs_router._reindex_runs.clear()
+    docs_router._user_active_run.clear()
+    yield
+    docs_router._reindex_runs.clear()
+    docs_router._user_active_run.clear()
+
+
+def test_reindex_returns_run_id_and_initial_state(app_client, clean_reindex_state):
+    upload(app_client, "iec61508.pdf")
+    r = app_client.post("/documents/reindex")
+    assert r.status_code == 200
+    body = r.json()
+    assert "run_id" in body and body["run_id"]
+    # The endpoint returns immediately; status may already be "completed"
+    # because TestClient drains BackgroundTasks before returning, but in
+    # either case the shape must include the progress fields.
+    assert body["status"] in {"running", "completed"}
+    assert "docs_total" in body
+    assert "chunks_total" in body
+    assert "scope" in body and body["scope"] == {"project_id": None, "client_id": None}
+
+
+def test_reindex_idempotent_per_user_while_active(app_client, clean_reindex_state):
+    """Two POSTs without an intervening completion should share a run_id.
+    Forced by pre-seeding an in-flight run so the second POST sees it."""
+    from routers import documents as docs_router
+    upload(app_client, "doc.pdf")
+    # Inject a sentinel "running" run for USER and assert the second POST
+    # returns it instead of starting a new one.
+    docs_router._reindex_runs["sentinel-run"] = {
+        "run_id": "sentinel-run", "user_email": USER, "status": "running",
+        "started_at": "2026-04-20T00:00:00+00:00", "completed_at": None,
+        "scope": {"project_id": None, "client_id": None},
+        "docs_total": 1, "docs_done": 0, "chunks_total": 0, "chunks_done": 0,
+        "current_doc": None, "rate_samples": [], "error": None,
+    }
+    docs_router._user_active_run[USER] = "sentinel-run"
+
+    r = app_client.post("/documents/reindex")
+    assert r.status_code == 200
+    assert r.json()["run_id"] == "sentinel-run"
+
+
+def test_reindex_status_by_run_id(app_client, clean_reindex_state):
+    upload(app_client, "doc.pdf")
+    run_id = app_client.post("/documents/reindex").json()["run_id"]
+    r = app_client.get(f"/documents/reindex/status?run_id={run_id}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["run_id"] == run_id
+    assert body["status"] in {"running", "completed"}
+
+
+def test_reindex_status_without_run_id_returns_user_run(app_client, clean_reindex_state):
+    upload(app_client, "doc.pdf")
+    run_id = app_client.post("/documents/reindex").json()["run_id"]
+    r = app_client.get("/documents/reindex/status")
+    assert r.status_code == 200
+    assert r.json()["run_id"] == run_id
+
+
+def test_reindex_status_unknown_run_id_returns_404(app_client, clean_reindex_state):
+    r = app_client.get("/documents/reindex/status?run_id=does-not-exist")
+    assert r.status_code == 404
+
+
+def test_reindex_status_no_runs_for_user_returns_404(app_client, clean_reindex_state):
+    r = app_client.get("/documents/reindex/status")
+    assert r.status_code == 404
+
+
+def test_reindex_status_other_user_run_returns_404(app_client, clean_reindex_state):
+    """A user must not be able to read another user's run state."""
+    from routers import documents as docs_router
+    docs_router._reindex_runs["other-user-run"] = {
+        "run_id": "other-user-run", "user_email": "someone-else@dev",
+        "status": "running", "started_at": "2026-04-20T00:00:00+00:00",
+        "completed_at": None, "scope": {"project_id": None, "client_id": None},
+        "docs_total": 0, "docs_done": 0, "chunks_total": 0, "chunks_done": 0,
+        "current_doc": None, "rate_samples": [], "error": None,
+    }
+    r = app_client.get("/documents/reindex/status?run_id=other-user-run")
+    assert r.status_code == 404

--- a/web/app.js
+++ b/web/app.js
@@ -2393,28 +2393,120 @@ const wbReindexAllBtn     = document.getElementById('wb-reindex-all-btn');
 const wbMigrateScopeBtn   = document.getElementById('wb-migrate-scope-btn');
 const wbMaintenanceStatus = document.getElementById('wb-maintenance-status');
 
+const REINDEX_POLL_MS = 3000;
+let _reindexPollTimer = null;
+
+function _formatEta(seconds) {
+  if (seconds == null) return '~ETA pending';
+  if (seconds < 60)    return `~${seconds}s remaining`;
+  const mins = Math.round(seconds / 60);
+  if (mins < 60)       return `~${mins} min remaining`;
+  const hrs  = Math.floor(mins / 60);
+  const rem  = mins % 60;
+  return `~${hrs}h ${rem}m remaining`;
+}
+
+function _renderReindexProgress(statusEl, state) {
+  if (!state) { statusEl.innerHTML = ''; statusEl.textContent = ''; return; }
+  const pct = state.chunks_total > 0
+    ? Math.min(100, Math.round((state.chunks_done / state.chunks_total) * 100))
+    : 0;
+  let label;
+  if (state.status === 'completed') {
+    label = `Done — ${state.docs_done} doc(s), ${state.chunks_done} chunk(s)`;
+  } else if (state.status === 'failed') {
+    label = `Failed — ${state.error || 'unknown error'}`;
+  } else {
+    const cur = state.current_doc;
+    const docPart   = `doc ${state.docs_done + (cur ? 1 : 0)}/${state.docs_total}`;
+    const chunkPart = `${state.chunks_done.toLocaleString()} / ${state.chunks_total.toLocaleString()} chunks`;
+    label = `Reindexing — ${docPart} · ${chunkPart} · ${_formatEta(state.eta_seconds)}`;
+  }
+  const klass = state.status === 'failed' ? 'reindex-progress is-failed' : 'reindex-progress';
+  statusEl.innerHTML = `
+    <div class="${klass}">
+      <div class="reindex-bar-track"><div class="reindex-bar-fill" style="width:${pct}%"></div></div>
+      <span class="reindex-label"></span>
+    </div>`;
+  statusEl.querySelector('.reindex-label').textContent = label;
+}
+
+function _stopReindexPoll() {
+  if (_reindexPollTimer) { clearTimeout(_reindexPollTimer); _reindexPollTimer = null; }
+}
+
+async function _pollReindex(runId, statusEl, btns) {
+  try {
+    const res = await fetch('/api/documents/reindex/status?run_id=' + encodeURIComponent(runId));
+    if (!res.ok) {
+      _renderReindexProgress(statusEl, null);
+      btns.forEach(b => { if (b) b.disabled = false; });
+      return;
+    }
+    const state = await res.json();
+    _renderReindexProgress(statusEl, state);
+    if (state.status === 'running') {
+      _reindexPollTimer = setTimeout(() => _pollReindex(runId, statusEl, btns), REINDEX_POLL_MS);
+    } else {
+      btns.forEach(b => { if (b) b.disabled = false; });
+      // Leave the final state visible briefly, then clear.
+      setTimeout(() => _renderReindexProgress(statusEl, null), 12000);
+    }
+  } catch (e) {
+    _renderReindexProgress(statusEl, null);
+    btns.forEach(b => { if (b) b.disabled = false; });
+  }
+}
+
 async function runReindex(params = {}) {
   const qs = new URLSearchParams(params).toString();
   const url = '/api/documents/reindex' + (qs ? '?' + qs : '');
-  const btn = params.project_id || params.client_id ? wbReindexBtn : wbReindexAllBtn;
-  const statusEl = params.project_id || params.client_id ? wbUploadStatus : wbMaintenanceStatus;
-  btn.disabled = true;
-  statusEl.textContent = 'Re-indexing…';
+  const scoped   = params.project_id || params.client_id;
+  const statusEl = scoped ? wbUploadStatus : wbMaintenanceStatus;
+  const btns     = [wbReindexBtn, wbReindexAllBtn];
+  _stopReindexPoll();
+  btns.forEach(b => { if (b) b.disabled = true; });
+  _renderReindexProgress(statusEl, {
+    status: 'running', docs_total: 0, docs_done: 0,
+    chunks_total: 0, chunks_done: 0, current_doc: null, eta_seconds: null,
+  });
   try {
     const res = await fetch(url, { method: 'POST' });
     const data = await res.json().catch(() => ({}));
-    if (res.ok) {
-      statusEl.textContent = `Done — ${data.docs_reindexed} doc(s), ${data.chunks_processed} chunk(s)`;
-    } else {
-      statusEl.textContent = data.detail || 'Re-index failed.';
+    if (!res.ok || !data.run_id) {
+      _renderReindexProgress(statusEl, null);
+      statusEl.textContent = data.detail || 'Re-index failed to start.';
+      btns.forEach(b => { if (b) b.disabled = false; });
+      setTimeout(() => { statusEl.textContent = ''; }, 8000);
+      return;
     }
+    _renderReindexProgress(statusEl, data);
+    _pollReindex(data.run_id, statusEl, btns);
   } catch (e) {
+    _renderReindexProgress(statusEl, null);
     statusEl.textContent = 'Re-index error.';
-  } finally {
-    btn.disabled = false;
+    btns.forEach(b => { if (b) b.disabled = false; });
     setTimeout(() => { statusEl.textContent = ''; }, 8000);
   }
 }
+
+// On page load, resume polling if a reindex is already in flight (e.g. the
+// page was refreshed mid-run, or another tab kicked one off).
+async function resumeReindexPollIfActive() {
+  try {
+    const res = await fetch('/api/documents/reindex/status');
+    if (!res.ok) return;
+    const state = await res.json();
+    if (state.status !== 'running') return;
+    const scoped = state.scope && (state.scope.project_id || state.scope.client_id);
+    const statusEl = scoped ? wbUploadStatus : wbMaintenanceStatus;
+    const btns = [wbReindexBtn, wbReindexAllBtn];
+    btns.forEach(b => { if (b) b.disabled = true; });
+    _renderReindexProgress(statusEl, state);
+    _pollReindex(state.run_id, statusEl, btns);
+  } catch (e) { /* no active run */ }
+}
+resumeReindexPollIfActive();
 
 wbReindexBtn.addEventListener('click', () => {
   const params = {};

--- a/web/styles.css
+++ b/web/styles.css
@@ -1524,6 +1524,37 @@ body { display: block; }
   font-style: italic;
 }
 
+.reindex-progress {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 240px;
+  font-style: normal;
+}
+.reindex-progress .reindex-bar-track {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  height: 6px;
+  overflow: hidden;
+}
+.reindex-progress .reindex-bar-fill {
+  background: var(--gold);
+  height: 100%;
+  width: 0%;
+  transition: width 0.4s ease;
+}
+.reindex-progress.is-failed .reindex-bar-fill {
+  background: var(--error);
+}
+.reindex-progress .reindex-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .wb-table-wrap {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
Closes #52

## Summary

`POST /documents/reindex` was synchronous and opaque — while it ran, the only signal was merLLM's queue depth, which (correctly) shows individual chunk rows and can't know that 770+ rows are one logical operation. A 57-doc reindex looked indistinguishable from a runaway from the merLLM dashboard.

This PR makes lancellmot the source of truth for reindex progress:

- `POST /documents/reindex` returns immediately with `{run_id, status, docs_total, …}` and runs the work as a `BackgroundTasks` job. No more orphaned loops on HTTP 499 — the work is no longer tied to the request lifecycle.
- `GET /documents/reindex/status?run_id=X` returns full run state: `docs_done/docs_total`, `chunks_done/chunks_total`, `current_doc`, best-effort `eta_seconds`. Without `run_id`, returns the calling user's most recent run (so a page refresh mid-run resumes its progress bar).
- Per-user idempotency: a second POST while a run is in flight returns the existing `run_id` instead of starting a parallel run.
- ETA: 120 s rolling rate over actual chunk completions; null until at least two samples have landed. Issue notes that ETA accuracy isn't required — a moving average over real progress is honest enough.
- Frontend: the maintenance/upload status spans now render a structured progress component (track + fill + label) instead of a one-shot string. `resumeReindexPollIfActive()` picks up an in-flight run on page load.
- README endpoint table updated.

## Test results

- 146/146 pytest pass (full suite).
- 7 new tests cover the API surface: `run_id` returned, idempotency (via injected sentinel run), status by id, status without id (returns user's run), 404 for unknown run, 404 when no runs exist, 404 on cross-user lookup.

## Scope decisions

- Run state lives in module-level dicts (`_reindex_runs`, `_user_active_run`), matching the existing `_active_uploads` pattern. The issue explicitly said in-memory is fine — a killed reindex was already unrecoverable, so persistence buys nothing here.
- Mid-doc chunk progress is not surfaced (chunks advance in lockstep with each doc completing, since `extract_chunks_batch` returns the full list at once). `current_doc.chunks_done` jumps from 0 to N at completion. Within-doc granularity would require changing `extract_chunks_batch`'s contract — out of scope.
- Cancel button: noted in the issue as a natural follow-up; not implemented in v1.

**Visual verification pending — automated agent. Manual browser check required before merge.** Specifically: kick off a reindex, watch the bar fill smoothly, refresh mid-run and confirm the bar reattaches, and verify the second click while running reuses the same run_id rather than stalling.