### PR TITLE
extractor: controls-engineering framing + vocab (#50)

### DIFF
--- a/api/extractor.py
+++ b/api/extractor.py
@@ -149,6 +149,44 @@ CONCEPT_VOCAB: list[str] = [
     "software validation",
     "change management",
     "configuration management",
+    # Controls engineering — logic / programming
+    "plc program",
+    "ladder logic",
+    "function block",
+    "structured text",
+    "scan cycle",
+    "tag name",
+    "io mapping",
+    # Controls engineering — operational modes
+    "interlock",
+    "permissive",
+    "bypass",
+    "manual override",
+    "hand/off/auto",
+    # HMI / SCADA
+    "hmi screen",
+    "alarm setpoint",
+    "trend group",
+    "operator permission",
+    # Instrumentation
+    "pid loop",
+    "loop tuning",
+    "analog scaling",
+    "instrument range",
+    "transmitter",
+    # Motors / drives / power
+    "vfd drive",
+    "motor starter",
+    "soft start",
+    "drive parameter",
+    "motor control center",
+    "safety relay",
+    # Engineering documentation
+    "p&id",
+    "loop diagram",
+    "wiring diagram",
+    "sequence of operations",
+    "functional description",
     # Document roles (not concepts per se but useful for classification)
 ]
 
@@ -212,7 +250,7 @@ def _build_system_prompt(extra_vocab: list[str] | None = None) -> str:
                 merged.append(c)
                 existing.add(c)
     vocab_block = "\n".join(f"  - {c}" for c in merged)
-    return f"""You are a functional-safety document analyst.
+    return f"""You are a controls-engineering document analyst with functional-safety depth.
 Your task is to extract structured metadata from a document chunk.
 Return ONLY a JSON object — no prose, no markdown fences, no explanation.
 

--- a/api/tests/test_extractor_batch.py
+++ b/api/tests/test_extractor_batch.py
@@ -135,7 +135,7 @@ async def test_extract_chunks_batch_flattens_messages_into_single_prompt(monkeyp
     # Prompt must contain both the system-level instructions (vocabulary,
     # schema) and the user-level chunk text.
     prompt = submitted[0]
-    assert "functional-safety document analyst" in prompt
+    assert "controls-engineering document analyst with functional-safety depth" in prompt
     assert "tell me about SIL 2" in prompt
 
 


### PR DESCRIPTION
Closes #50

## Summary

Reframes the extractor system prompt at `api/extractor.py:215` from "functional-safety document analyst" to "controls-engineering document analyst with functional-safety depth", and extends `CONCEPT_VOCAB` with ~30 controls-engineering anchor terms (logic/programming, operational modes, HMI/SCADA, instrumentation, motors/drives, engineering documentation). The library mixes controls-only docs, FS-only docs, and hybrid docs; the prior FS-only framing was suppressing recall on controls-heavy chunks. Broadening the role alone would just produce noisy ad-hoc concepts, so the vocab block is extended in the same change to give the model canonical anchors to reuse on non-FS chunks.

Vocab now ~80 terms total, comfortably under `MAX_LEARNED_VOCAB=200` even with learned additions layered on top. JSON output contract unchanged.

## Test results

- 139/139 pytest pass (full suite, 62s).
- Updated the role-string assertion in `tests/test_extractor_batch.py` to match the new framing — the test's intent (verify the system prompt is included in the flattened batch payload) is preserved.
- Existing `test_build_system_prompt_*` cap/preservation tests continue to pass — the additional vocab fits well within the prompt-size ceiling.

## Out of scope

- `DOC_ROLES` enum (lines 157–167) — orthogonal to the controls/FS split.
- Reindexing the existing corpus — left as a separate decision; the new framing only takes effect on new extractions until a reindex runs.

**Visual verification pending — automated agent. Manual browser check required before merge.** Specifically: after merge + reindex, spot-check that controls-heavy chunks (PLC programs, HMI screens, drive parameters) now produce richer non-FS concept lists and that FS-heavy chunks haven't regressed.