### PR TITLE
extractor: broaden role framing from FS analyst to controls engineer (#50)

### DIFF
--- a/api/extractor.py
+++ b/api/extractor.py
@@ -161,7 +161,44 @@ CONCEPT_VOCAB: list[str] = [
     "software validation",
     "change management",
     "configuration management",
-    # Document roles (not concepts per se but useful for classification)
+    # Controls engineering — logic / programming
+    "plc program",
+    "ladder logic",
+    "function block",
+    "structured text",
+    "scan cycle",
+    "tag name",
+    "io mapping",
+    # Controls engineering — operational modes
+    "interlock",
+    "permissive",
+    "bypass",
+    "manual override",
+    "hand/off/auto",
+    # HMI / SCADA
+    "hmi screen",
+    "alarm setpoint",
+    "trend group",
+    "operator permission",
+    # Instrumentation
+    "pid loop",
+    "loop tuning",
+    "analog scaling",
+    "instrument range",
+    "transmitter",
+    # Motors / drives / power
+    "vfd drive",
+    "motor starter",
+    "soft start",
+    "drive parameter",
+    "motor control center",
+    "safety relay",
+    # Engineering documentation
+    "p&id",
+    "loop diagram",
+    "wiring diagram",
+    "sequence of operations",
+    "functional description",
 ]
 
 # ── Document roles ─────────────────────────────────────────────────────────────
@@ -224,7 +261,7 @@ def _build_system_prompt(extra_vocab: list[str] | None = None) -> str:
                 merged.append(c)
                 existing.add(c)
     vocab_block = "\n".join(f"  - {c}" for c in merged)
-    return f"""You are a functional-safety document analyst.
+    return f"""You are a controls-engineering document analyst with functional-safety depth.
 Your task is to extract structured metadata from a document chunk.
 Return ONLY a JSON object — no prose, no markdown fences, no explanation.
 

--- a/api/tests/test_extractor_batch.py
+++ b/api/tests/test_extractor_batch.py
@@ -134,9 +134,10 @@ async def test_extract_chunks_batch_flattens_messages_into_single_prompt(monkeyp
 
     assert len(submitted) == 1
     # Prompt must contain both the system-level instructions (vocabulary,
-    # schema) and the user-level chunk text.
+    # schema) and the user-level chunk text. Check for a durable marker of
+    # each: the JSON-schema intro (system) and the chunk text (user).
     prompt = submitted[0]
-    assert "functional-safety document analyst" in prompt
+    assert "JSON schema (all fields required)" in prompt
     assert "tell me about SIL 2" in prompt
 
 

--- a/api/tests/test_extractor_role_framing.py
+++ b/api/tests/test_extractor_role_framing.py
@@ -1,0 +1,93 @@
+"""
+test_extractor_role_framing.py — Pin the extractor's role framing and vocab.
+
+Guards hexcaliper-lanceLLMot#50: the original framing cast the model as a
+"functional-safety document analyst" with a ~50-term vocabulary that was
+~96% FS-standards-heavy (IEC 62061/61508/13849, FSM). In practice the
+document library mixes pure controls-engineering material (PLC programs,
+HMI screens, VFD parameters, P&IDs, sequences of operations) with FS
+material and hybrid docs. A FS-only framing suppressed recall on controls
+chunks and pushed the model to interpret everything through a SIL/PL lens.
+
+These tests lock in:
+  - role framing: controls-engineering primary, FS as a named specialty
+  - vocab coverage: controls-engineering anchors alongside the FS seeds,
+    so the model has canonical terms to reuse on non-FS chunks (otherwise
+    broadening the role alone just produces noisy ad-hoc concepts)
+  - no regression: the FS seeds that were already in place are still here
+"""
+import extractor
+
+
+def test_system_prompt_frames_role_as_controls_engineer():
+    """The role line must lead with controls engineering; FS is a specialty,
+    not the whole identity."""
+    prompt = extractor._build_system_prompt(None)
+    assert "controls-engineering document analyst" in prompt, (
+        "role framing must lead with controls engineering"
+    )
+    assert "functional safety" in prompt.lower() or "functional-safety" in prompt.lower(), (
+        "FS depth must still be named in the role line"
+    )
+    assert "You are a functional-safety document analyst." not in prompt, (
+        "old FS-only framing must be gone"
+    )
+
+
+def test_concept_vocab_includes_controls_engineering_anchors():
+    """Controls-engineering chunks need canonical terms to reuse. Without
+    these anchors, broadening the role just produces noisy ad-hoc concepts."""
+    expected_controls_anchors = {
+        # Logic / programming
+        "ladder logic",
+        "function block",
+        "structured text",
+        "tag name",
+        # Operational modes
+        "interlock",
+        "permissive",
+        "bypass",
+        # HMI / SCADA
+        "hmi screen",
+        "alarm setpoint",
+        # Instrumentation
+        "pid loop",
+        "analog scaling",
+        # Motors / drives
+        "vfd drive",
+        "motor starter",
+        "drive parameter",
+        # Engineering docs
+        "p&id",
+        "loop diagram",
+        "sequence of operations",
+    }
+    vocab = set(extractor.CONCEPT_VOCAB)
+    missing = expected_controls_anchors - vocab
+    assert not missing, f"controls-engineering anchors missing from CONCEPT_VOCAB: {sorted(missing)}"
+
+
+def test_concept_vocab_retains_functional_safety_seeds():
+    """Regression guard: broadening the role must not drop FS seeds. These
+    terms anchor the FS subset of the corpus and must remain."""
+    expected_fs_seeds = {
+        "safety integrity level",
+        "performance level",
+        "diagnostic coverage",
+        "proof test",
+        "hazard analysis",
+        "safety instrumented function",
+    }
+    vocab = set(extractor.CONCEPT_VOCAB)
+    missing = expected_fs_seeds - vocab
+    assert not missing, f"FS seeds dropped from CONCEPT_VOCAB: {sorted(missing)}"
+
+
+def test_concept_vocab_entries_are_lowercase_and_clean():
+    """CONCEPT_VOCAB entries become node IDs directly (see the module-level
+    comment at extractor.py:101). Must be lowercase with no leading/trailing
+    whitespace. Added terms need to honor this invariant."""
+    for term in extractor.CONCEPT_VOCAB:
+        assert term == term.lower(), f"non-lowercase vocab entry: {term!r}"
+        assert term == term.strip(), f"whitespace around vocab entry: {term!r}"
+        assert term, "empty string in CONCEPT_VOCAB"


### PR DESCRIPTION
## Summary
- Role line: `functional-safety document analyst` → `controls-engineering document analyst with functional-safety depth` — controls primary, FS a named specialty.
- `CONCEPT_VOCAB` +30 controls-engineering anchors (logic/programming, modes, HMI, instrumentation, drives, eng. docs). Seeded vocab ~80 terms; stays well under `MAX_LEARNED_VOCAB=200`.
- Rationale: corpus mixes pure controls + FS + hybrid docs. FS-only framing was pushing the model to interpret everything through a SIL/PL lens and under-recalling controls concepts.

## Test plan
- [x] New `test_extractor_role_framing.py`: pins role string, controls anchors, retained FS seeds, vocab hygiene (4 tests).
- [x] `test_extractor_batch.py` flatten check moved to a role-string-independent marker (`JSON schema (all fields required)`).
- [x] Full suite: 148 passed.
- [ ] Operator follow-up (out of scope for PR): re-run extraction on 5–10 controls-heavy chunks and 5–10 FS-heavy chunks; spot-check `concept_vocab` after a small reindex to confirm new anchors are being selected.

Closes #50.